### PR TITLE
M2-Phase 1: Token Observability (T1)

### DIFF
--- a/src/__tests__/e2e-phase3.test.ts
+++ b/src/__tests__/e2e-phase3.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
-import type { LLMProvider, LLMCallOptions } from '../core/llm-provider.js';
+import type { LLMProvider, LLMCallOptions, LLMResponse } from '../core/llm-provider.js';
 import { STAGE_ORDER } from '../core/types.js';
 
 // Mock provider with formatted responses for all 6 stages
@@ -19,16 +19,16 @@ class MockLLMProvider implements LLMProvider {
   callCount = 0;
   private uiBuilderCallCount = 0;
 
-  async call(_prompt: string, _options?: LLMCallOptions): Promise<string> {
+  async call(_prompt: string, _options?: LLMCallOptions): Promise<LLMResponse> {
     this.callCount++;
 
     // Detect UIDesigner sub-phases by system prompt
     const sys = _options?.systemPrompt ?? '';
     if (sys.includes('UIPlanner') || sys.includes('planning phase of the UI designer')) {
-      return this.plannerResponse();
+      return { content: this.plannerResponse() };
     }
     if (sys.includes('UIBuilder') || sys.includes('builder phase of the UI designer')) {
-      return this.builderResponse();
+      return { content: this.builderResponse() };
     }
 
     // Sequential stage dispatch for non-UIDesigner stages
@@ -156,7 +156,7 @@ paths:
 <!-- END:validation-report.md -->`,
     };
 
-    return responses[stage!] ?? '[mock] unknown';
+    return { content: responses[stage!] ?? '[mock] unknown' };
   }
 
   private plannerResponse(): string {

--- a/src/__tests__/e2e-phase4.test.ts
+++ b/src/__tests__/e2e-phase4.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
-import type { LLMProvider, LLMCallOptions } from '../core/llm-provider.js';
+import type { LLMProvider, LLMCallOptions, LLMResponse } from '../core/llm-provider.js';
 import { STAGE_ORDER } from '../core/types.js';
 import type { GitPlatformAdapter, CreateIssueParams, IssueComment, IssueDetails } from '../adapters/types.js';
 import type { GitHubConfig } from '../core/types.js';
@@ -118,17 +118,17 @@ class InMemoryGitPlatformAdapter implements GitPlatformAdapter {
 class MockLLMProvider implements LLMProvider {
   callCount = 0;
 
-  async call(_prompt: string, _options?: LLMCallOptions): Promise<string> {
+  async call(_prompt: string, _options?: LLMCallOptions): Promise<LLMResponse> {
     this.callCount++;
     const sys = _options?.systemPrompt ?? '';
 
     // UIDesigner planner sub-phase
     if (sys.includes('UIPlanner') || sys.includes('planning phase of the UI designer')) {
-      return `<!-- ARTIFACT:ui-plan.json -->\n{"components": [{"name": "CompA", "file": "components/CompA.tsx", "preview": "previews/CompA.html", "purpose": "Test component", "covers_flow": "main-flow", "parent": null, "children": [], "props": [], "priority": 1}]}\n<!-- END:ui-plan.json -->`;
+      return { content: `<!-- ARTIFACT:ui-plan.json -->\n{"components": [{"name": "CompA", "file": "components/CompA.tsx", "preview": "previews/CompA.html", "purpose": "Test component", "covers_flow": "main-flow", "parent": null, "children": [], "props": [], "priority": 1}]}\n<!-- END:ui-plan.json -->` };
     }
     // UIDesigner builder sub-phase
     if (sys.includes('UIBuilder') || sys.includes('builder phase of the UI designer')) {
-      return `<!-- ARTIFACT:components/CompA.tsx -->\nexport default function CompA() {\n  return <div className="p-4">Test</div>;\n}\n<!-- END:components/CompA.tsx -->\n\n<!-- ARTIFACT:previews/CompA.html -->\n<!DOCTYPE html><html><head><script src="https://cdn.tailwindcss.com"></script></head><body><div class="p-4">Test</div></body></html>\n<!-- END:previews/CompA.html -->`;
+      return { content: `<!-- ARTIFACT:components/CompA.tsx -->\nexport default function CompA() {\n  return <div className="p-4">Test</div>;\n}\n<!-- END:components/CompA.tsx -->\n\n<!-- ARTIFACT:previews/CompA.html -->\n<!DOCTYPE html><html><head><script src="https://cdn.tailwindcss.com"></script></head><body><div class="p-4">Test</div></body></html>\n<!-- END:previews/CompA.html -->` };
     }
 
     // Sequential stages (non-UI)
@@ -144,14 +144,14 @@ class MockLLMProvider implements LLMProvider {
     for (const [stage, response] of Object.entries(stageResponses)) {
       const artifactName = stage === 'researcher' ? 'research.md' : stage === 'product_owner' ? 'prd.md' : stage === 'ux_designer' ? 'ux-flows.md' : stage === 'api_designer' ? 'api-spec.yaml' : 'validation-report.md';
       if (_prompt.includes(artifactName) || sys.includes(stage.replace('_', ' '))) {
-        return response;
+        return { content: response };
       }
     }
 
     // Fallback: use call count for early sequential stages
     const nonUIStages = STAGE_ORDER.filter((s) => s !== 'ui_designer');
     const stage = nonUIStages[this.callCount - 1];
-    return stageResponses[stage] ?? '[mock] unknown stage';
+    return { content: stageResponses[stage] ?? '[mock] unknown stage' };
   }
 }
 

--- a/src/__tests__/e2e-phase5.test.ts
+++ b/src/__tests__/e2e-phase5.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
-import type { LLMProvider, LLMCallOptions } from '../core/llm-provider.js';
+import type { LLMProvider, LLMCallOptions, LLMResponse } from '../core/llm-provider.js';
 import type { StageName } from '../core/types.js';
 import { STAGE_ORDER } from '../core/types.js';
 import type { InteractionHandler, EvolutionApprovalResult } from '../core/interaction-handler.js';
@@ -36,7 +36,7 @@ class EvolutionMockProvider implements LLMProvider {
   // Configurable evolution response
   evolutionResponse: string = '[]';
 
-  async call(prompt: string, options?: LLMCallOptions): Promise<string> {
+  async call(prompt: string, options?: LLMCallOptions): Promise<LLMResponse> {
     this.callCount++;
     this.promptsSeen.push(prompt);
     if (options?.systemPrompt) {
@@ -45,17 +45,17 @@ class EvolutionMockProvider implements LLMProvider {
 
     // If this is an evolution analysis call (has evolution analyst system prompt)
     if (options?.systemPrompt?.includes('evolution analyst')) {
-      return this.evolutionResponse;
+      return { content: this.evolutionResponse };
     }
 
     // UIDesigner planner sub-phase
     const sys = options?.systemPrompt ?? '';
     if (sys.includes('UIPlanner') || sys.includes('planning phase of the UI designer')) {
-      return `<!-- ARTIFACT:ui-plan.json -->\n{"components": [{"name": "CompA", "file": "components/CompA.tsx", "preview": "previews/CompA.html", "purpose": "Test", "covers_flow": "main-flow", "parent": null, "children": [], "props": [], "priority": 1}]}\n<!-- END:ui-plan.json -->`;
+      return { content: `<!-- ARTIFACT:ui-plan.json -->\n{"components": [{"name": "CompA", "file": "components/CompA.tsx", "preview": "previews/CompA.html", "purpose": "Test", "covers_flow": "main-flow", "parent": null, "children": [], "props": [], "priority": 1}]}\n<!-- END:ui-plan.json -->` };
     }
     // UIDesigner builder sub-phase
     if (sys.includes('UIBuilder') || sys.includes('builder phase of the UI designer')) {
-      return `<!-- ARTIFACT:components/CompA.tsx -->\nexport default function CompA() {\n  return <div className="p-4">Test</div>;\n}\n<!-- END:components/CompA.tsx -->\n\n<!-- ARTIFACT:previews/CompA.html -->\n<!DOCTYPE html><html><head><script src="https://cdn.tailwindcss.com"></script></head><body><div class="p-4">Test</div></body></html>\n<!-- END:previews/CompA.html -->`;
+      return { content: `<!-- ARTIFACT:components/CompA.tsx -->\nexport default function CompA() {\n  return <div className="p-4">Test</div>;\n}\n<!-- END:components/CompA.tsx -->\n\n<!-- ARTIFACT:previews/CompA.html -->\n<!DOCTYPE html><html><head><script src="https://cdn.tailwindcss.com"></script></head><body><div class="p-4">Test</div></body></html>\n<!-- END:previews/CompA.html -->` };
     }
 
     // Normal pipeline stage responses
@@ -71,7 +71,7 @@ class EvolutionMockProvider implements LLMProvider {
       validator: `<!-- ARTIFACT:validation-report.md -->\n## Validation Summary\n- Status: PASS\n- Checks passed: 4/4\n<!-- END:validation-report.md -->`,
     };
 
-    return responses[stage] ?? '[mock] unknown';
+    return { content: responses[stage] ?? '[mock] unknown' };
   }
 }
 

--- a/src/agents/__tests__/ui-designer.test.ts
+++ b/src/agents/__tests__/ui-designer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
-import type { LLMProvider, LLMCallOptions } from '../../core/llm-provider.js';
+import type { LLMProvider, LLMCallOptions, LLMResponse } from '../../core/llm-provider.js';
 import type { AgentContext } from '../../core/types.js';
 import { ClarificationNeeded } from '../../core/types.js';
 import { UIDesignerAgent } from '../ui-designer.js';
@@ -15,14 +15,14 @@ class MockUIProvider implements LLMProvider {
   // Set to true to make the second builder call fail
   failOnBuilder = 0;
 
-  async call(prompt: string, options?: LLMCallOptions): Promise<string> {
+  async call(prompt: string, options?: LLMCallOptions): Promise<LLMResponse> {
     this.callCount++;
     this.calls.push({ prompt, systemPrompt: options?.systemPrompt });
     const sys = options?.systemPrompt ?? '';
 
     // Planner
     if (sys.includes('UIPlanner') || sys.includes('planning phase of the UI designer')) {
-      return `<!-- ARTIFACT:ui-plan.json -->
+      return { content: `<!-- ARTIFACT:ui-plan.json -->
 {
   "design_tokens": {"primary": "blue-600"},
   "components": [
@@ -30,7 +30,7 @@ class MockUIProvider implements LLMProvider {
     {"name": "CompB", "file": "components/CompB.tsx", "preview": "previews/CompB.html", "purpose": "Second component", "covers_flow": "flow-b", "parent": null, "children": [], "props": [], "priority": 2}
   ]
 }
-<!-- END:ui-plan.json -->`;
+<!-- END:ui-plan.json -->` };
     }
 
     // Builder
@@ -55,10 +55,10 @@ class MockUIProvider implements LLMProvider {
       };
 
       const comp = components[this.builderCallCount] ?? components[1];
-      return `<!-- ARTIFACT:components/${comp.name}.tsx -->\n${comp.tsx}\n<!-- END:components/${comp.name}.tsx -->\n\n<!-- ARTIFACT:previews/${comp.name}.html -->\n${comp.html}\n<!-- END:previews/${comp.name}.html -->`;
+      return { content: `<!-- ARTIFACT:components/${comp.name}.tsx -->\n${comp.tsx}\n<!-- END:components/${comp.name}.tsx -->\n\n<!-- ARTIFACT:previews/${comp.name}.html -->\n${comp.html}\n<!-- END:previews/${comp.name}.html -->` };
     }
 
-    return '[unknown call]';
+    return { content: '[unknown call]' };
   }
 }
 
@@ -183,8 +183,8 @@ describe('UIDesignerAgent', () => {
 
   it('should throw ClarificationNeeded when planner requests clarification', async () => {
     const provider: LLMProvider = {
-      async call(_prompt: string, _options?: LLMCallOptions) {
-        return `<!-- CLARIFICATION -->
+      async call(_prompt: string, _options?: LLMCallOptions): Promise<LLMResponse> {
+        return { content: `<!-- CLARIFICATION -->
 {
   "question": "Pick a style:",
   "options": [
@@ -193,7 +193,7 @@ describe('UIDesignerAgent', () => {
   ],
   "allow_custom": true
 }
-<!-- END:CLARIFICATION -->`;
+<!-- END:CLARIFICATION -->` };
       },
     };
 

--- a/src/agents/__tests__/validator.test.ts
+++ b/src/agents/__tests__/validator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
-import type { LLMProvider, LLMCallOptions } from '../../core/llm-provider.js';
+import type { LLMProvider, LLMCallOptions, LLMResponse } from '../../core/llm-provider.js';
 import type { AgentContext } from '../../core/types.js';
 import { ValidatorAgent } from '../validator.js';
 import { Logger } from '../../core/logger.js';
@@ -10,8 +10,8 @@ import { writeManifest } from '../../core/manifest.js';
 const ARTIFACTS_DIR = '.mosaic/artifacts';
 
 class MockValidatorProvider implements LLMProvider {
-  async call(_prompt: string, _options?: LLMCallOptions): Promise<string> {
-    return `<!-- ARTIFACT:validation-report.md -->
+  async call(_prompt: string, _options?: LLMCallOptions): Promise<LLMResponse> {
+    return { content: `<!-- ARTIFACT:validation-report.md -->
 ## Validation Summary
 - Status: PASS
 - Checks passed: 4/4
@@ -27,7 +27,7 @@ class MockValidatorProvider implements LLMProvider {
 
 ### Check 4: Naming Consistency
 - Status: PASS
-<!-- END:validation-report.md -->`;
+<!-- END:validation-report.md -->` };
   }
 }
 

--- a/src/agents/llm-agent.ts
+++ b/src/agents/llm-agent.ts
@@ -18,14 +18,20 @@ export abstract class LLMAgent extends BaseAgent {
     });
     eventBus.emit('agent:thinking', this.stage, prompt.length);
 
-    const raw = await this.provider.call(prompt, {
+    const response = await this.provider.call(prompt, {
       systemPrompt: context.systemPrompt,
     });
+    const raw = response.content;
 
     this.logger.agent(this.stage, 'info', 'llm:response', {
       responseLength: raw.length,
+      usage: response.usage,
     });
     eventBus.emit('agent:response', this.stage, raw.length);
+
+    if (response.usage) {
+      eventBus.emit('agent:usage', this.stage, response.usage);
+    }
 
     const parsed = parseResponse(raw, spec.artifacts, spec.manifest);
 

--- a/src/agents/ui-designer.ts
+++ b/src/agents/ui-designer.ts
@@ -5,6 +5,7 @@ import { ClarificationNeeded } from '../core/types.js';
 import { BaseAgent } from '../core/agent.js';
 import type { OutputSpec } from '../core/prompt-assembler.js';
 import { eventBus } from '../core/event-bus.js';
+import type { LLMUsage } from '../core/llm-provider.js';
 import { UIPlanSchema, type UIPlan, type UIPlanComponent } from './ui-plan-schema.js';
 
 const PLANNER_PROMPT_PATH = '.claude/agents/mosaic/ui-planner.md';
@@ -16,6 +17,8 @@ const FULL_SIBLING_COUNT = 2;
 const SIBLING_SUMMARY_LINES = 15;
 
 export class UIDesignerAgent extends BaseAgent {
+  private totalUsage: LLMUsage = { input_tokens: 0, output_tokens: 0 };
+
   getOutputSpec(): OutputSpec {
     return {
       artifacts: ['components/', 'previews/', 'gallery.html'],
@@ -23,7 +26,26 @@ export class UIDesignerAgent extends BaseAgent {
     };
   }
 
+  private accumulateUsage(usage?: LLMUsage): void {
+    if (!usage) return;
+    this.totalUsage.input_tokens += usage.input_tokens;
+    this.totalUsage.output_tokens += usage.output_tokens;
+    if (usage.cache_creation_input_tokens) {
+      this.totalUsage.cache_creation_input_tokens =
+        (this.totalUsage.cache_creation_input_tokens ?? 0) + usage.cache_creation_input_tokens;
+    }
+    if (usage.cache_read_input_tokens) {
+      this.totalUsage.cache_read_input_tokens =
+        (this.totalUsage.cache_read_input_tokens ?? 0) + usage.cache_read_input_tokens;
+    }
+    if (usage.cost_usd != null) {
+      this.totalUsage.cost_usd = (this.totalUsage.cost_usd ?? 0) + usage.cost_usd;
+    }
+  }
+
   protected async run(context: AgentContext): Promise<void> {
+    this.totalUsage = { input_tokens: 0, output_tokens: 0 };
+
     // Phase A: Plan
     const plan = await this.runPlanner(context);
 
@@ -32,6 +54,11 @@ export class UIDesignerAgent extends BaseAgent {
 
     // Phase C: Post-processing (no LLM)
     await this.postProcess(plan, builtComponents);
+
+    // Emit accumulated usage for entire UIDesigner stage
+    if (this.totalUsage.input_tokens > 0 || this.totalUsage.output_tokens > 0) {
+      eventBus.emit('agent:usage', this.stage, this.totalUsage);
+    }
   }
 
   private async runPlanner(context: AgentContext): Promise<UIPlan> {
@@ -43,12 +70,15 @@ export class UIDesignerAgent extends BaseAgent {
     });
     eventBus.emit('agent:thinking', this.stage, userPrompt.length);
 
-    const raw = await this.provider.call(userPrompt, {
+    const response = await this.provider.call(userPrompt, {
       systemPrompt: plannerPrompt,
     });
+    const raw = response.content;
+    this.accumulateUsage(response.usage);
 
     this.logger.agent(this.stage, 'info', 'planner:response', {
       responseLength: raw.length,
+      usage: response.usage,
     });
     eventBus.emit('agent:response', this.stage, raw.length);
 
@@ -125,13 +155,16 @@ export class UIDesignerAgent extends BaseAgent {
         });
         eventBus.emit('agent:thinking', this.stage, userPrompt.length);
 
-        const raw = await this.provider.call(userPrompt, {
+        const response = await this.provider.call(userPrompt, {
           systemPrompt: builderPrompt,
         });
+        const raw = response.content;
+        this.accumulateUsage(response.usage);
 
         this.logger.agent(this.stage, 'info', 'builder:response', {
           component: comp.name,
           responseLength: raw.length,
+          usage: response.usage,
         });
 
         // Extract tsx and html artifacts

--- a/src/agents/validator.ts
+++ b/src/agents/validator.ts
@@ -23,14 +23,20 @@ export class ValidatorAgent extends BaseAgent {
     });
     eventBus.emit('agent:thinking', this.stage, prompt.length);
 
-    const raw = await this.provider.call(prompt, {
+    const response = await this.provider.call(prompt, {
       systemPrompt: context.systemPrompt,
     });
+    const raw = response.content;
 
     this.logger.agent(this.stage, 'info', 'llm:response', {
       responseLength: raw.length,
+      usage: response.usage,
     });
     eventBus.emit('agent:response', this.stage, raw.length);
+
+    if (response.usage) {
+      eventBus.emit('agent:usage', this.stage, response.usage);
+    }
 
     // Check for clarification (shouldn't happen for validator, but handle defensively)
     const clarificationMatch = raw.match(

--- a/src/core/__tests__/orchestrator-integration.test.ts
+++ b/src/core/__tests__/orchestrator-integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
-import type { LLMProvider, LLMCallOptions } from '../llm-provider.js';
+import type { LLMProvider, LLMCallOptions, LLMResponse } from '../llm-provider.js';
 import { Orchestrator } from '../orchestrator.js';
 import { STAGE_ORDER } from '../types.js';
 
@@ -9,13 +9,13 @@ class MockLLMProvider implements LLMProvider {
   callCount = 0;
   private uiBuilderCallCount = 0;
 
-  async call(_prompt: string, _options?: LLMCallOptions): Promise<string> {
+  async call(_prompt: string, _options?: LLMCallOptions): Promise<LLMResponse> {
     this.callCount++;
     const sys = _options?.systemPrompt ?? '';
 
     // UIDesigner planner sub-phase
     if (sys.includes('UIPlanner') || sys.includes('planning phase of the UI designer')) {
-      return `<!-- ARTIFACT:ui-plan.json -->
+      return { content: `<!-- ARTIFACT:ui-plan.json -->
 {
   "components": [
     {"name": "AuthForm", "file": "components/AuthForm.tsx", "preview": "previews/AuthForm.html", "purpose": "Login/register form", "covers_flow": "auth-flow", "parent": null, "children": [], "props": [], "priority": 1},
@@ -24,7 +24,7 @@ class MockLLMProvider implements LLMProvider {
     {"name": "CommentSection", "file": "components/CommentSection.tsx", "preview": "previews/CommentSection.html", "purpose": "Comment thread", "covers_flow": "reader-flow", "parent": null, "children": [], "props": [], "priority": 4}
   ]
 }
-<!-- END:ui-plan.json -->`;
+<!-- END:ui-plan.json -->` };
     }
 
     // UIDesigner builder sub-phase
@@ -36,7 +36,7 @@ class MockLLMProvider implements LLMProvider {
         3: `<!-- ARTIFACT:components/PostList.tsx -->\nexport default function PostList() {\n  return (\n    <div className="p-4 max-w-2xl mx-auto">\n      <h1 className="text-2xl font-bold mb-4">Blog Posts</h1>\n      <div className="space-y-4"><div className="p-4 border rounded"><h2 className="text-xl">Sample Post</h2><p className="text-gray-600">Post preview...</p></div></div>\n    </div>\n  );\n}\n<!-- END:components/PostList.tsx -->\n\n<!-- ARTIFACT:previews/PostList.html -->\n<!DOCTYPE html><html><head><script src="https://cdn.tailwindcss.com"></script></head><body><div class="p-4 max-w-2xl mx-auto"><h1 class="text-2xl font-bold mb-4">Blog Posts</h1><div class="space-y-4"><div class="p-4 border rounded"><h2 class="text-xl">Sample Post</h2><p class="text-gray-600">Post preview...</p></div></div></div></body></html>\n<!-- END:previews/PostList.html -->`,
         4: `<!-- ARTIFACT:components/CommentSection.tsx -->\nexport default function CommentSection() {\n  return (\n    <div className="p-4 border-t mt-4">\n      <h3 className="text-lg font-bold mb-2">Comments</h3>\n      <textarea placeholder="Add a comment..." className="w-full p-2 border rounded mb-2" />\n      <button className="bg-blue-500 text-white px-4 py-1 rounded">Submit</button>\n    </div>\n  );\n}\n<!-- END:components/CommentSection.tsx -->\n\n<!-- ARTIFACT:previews/CommentSection.html -->\n<!DOCTYPE html><html><head><script src="https://cdn.tailwindcss.com"></script></head><body><div class="p-4 border-t mt-4"><h3 class="text-lg font-bold mb-2">Comments</h3><textarea placeholder="Add a comment..." class="w-full p-2 border rounded mb-2"></textarea><button class="bg-blue-500 text-white px-4 py-1 rounded">Submit</button></div></body></html>\n<!-- END:previews/CommentSection.html -->`,
       };
-      return builders[this.uiBuilderCallCount] ?? builders[1]!;
+      return { content: builders[this.uiBuilderCallCount] ?? builders[1]! };
     }
 
     // Determine which stage based on call count (non-UI stages)
@@ -45,7 +45,7 @@ class MockLLMProvider implements LLMProvider {
 
     switch (stage) {
       case 'researcher':
-        return `
+        return { content: `
 <!-- ARTIFACT:research.md -->
 ## Market Overview
 The blog platform market is mature with established players.
@@ -66,10 +66,10 @@ High feasibility — standard CRUD with auth.
 
 <!-- MANIFEST:research.manifest.json -->
 {"competitors": ["WordPress", "Medium"], "key_insights": ["simplicity-focus", "mobile-first"], "feasibility": "high", "risks": ["market-saturation"]}
-<!-- END:MANIFEST -->`;
+<!-- END:MANIFEST -->` };
 
       case 'product_owner':
-        return `
+        return { content: `
 <!-- ARTIFACT:prd.md -->
 ## Goal
 Build a simple, modern blog platform for individual creators.
@@ -90,10 +90,10 @@ Build a simple, modern blog platform for individual creators.
 
 <!-- MANIFEST:prd.manifest.json -->
 {"features": ["user-auth", "blog-crud", "blog-comments"], "constraints": ["markdown-support", "performance-200ms"], "out_of_scope": ["multi-tenancy", "payments"]}
-<!-- END:MANIFEST -->`;
+<!-- END:MANIFEST -->` };
 
       case 'ux_designer':
-        return `
+        return { content: `
 <!-- ARTIFACT:ux-flows.md -->
 ## User Journeys
 ### Flow 1: auth-flow
@@ -118,10 +118,10 @@ Browse → Read Post → Comment
 
 <!-- MANIFEST:ux-flows.manifest.json -->
 {"flows": ["auth-flow", "blog-management", "reader-flow"], "components": ["AuthForm", "PostEditor", "PostList", "CommentSection"], "interaction_rules": ["form-validation", "loading-states"]}
-<!-- END:MANIFEST -->`;
+<!-- END:MANIFEST -->` };
 
       case 'api_designer':
-        return `
+        return { content: `
 <!-- ARTIFACT:api-spec.yaml -->
 openapi: "3.0.0"
 info:
@@ -161,10 +161,10 @@ paths:
 
 <!-- MANIFEST:api-spec.manifest.json -->
 {"endpoints": [{"method": "POST", "path": "/auth/register", "covers_feature": "user-auth"}, {"method": "POST", "path": "/auth/login", "covers_feature": "user-auth"}, {"method": "GET", "path": "/posts", "covers_feature": "blog-crud"}, {"method": "POST", "path": "/posts", "covers_feature": "blog-crud"}, {"method": "POST", "path": "/posts/{id}/comments", "covers_feature": "blog-comments"}], "models": ["User", "Post", "Comment"]}
-<!-- END:MANIFEST -->`;
+<!-- END:MANIFEST -->` };
 
       case 'validator':
-        return `
+        return { content: `
 <!-- ARTIFACT:validation-report.md -->
 ## Validation Summary
 - Status: PASS
@@ -189,10 +189,10 @@ paths:
 ### Check 4: Naming Consistency
 - Status: PASS
 - Terminology consistent across artifacts
-<!-- END:validation-report.md -->`;
+<!-- END:validation-report.md -->` };
 
       default:
-        return '[mock] Unknown stage';
+        return { content: '[mock] Unknown stage' };
     }
   }
 }

--- a/src/core/__tests__/run-manager.test.ts
+++ b/src/core/__tests__/run-manager.test.ts
@@ -1,23 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
-import type { LLMProvider, LLMCallOptions } from '../llm-provider.js';
+import type { LLMProvider, LLMCallOptions, LLMResponse } from '../llm-provider.js';
 import { STAGE_ORDER } from '../types.js';
 
 // Mock provider — routes UIDesigner sub-phases by system prompt
 class MockLLMProvider implements LLMProvider {
   callCount = 0;
 
-  async call(_prompt: string, _options?: LLMCallOptions): Promise<string> {
+  async call(_prompt: string, _options?: LLMCallOptions): Promise<LLMResponse> {
     this.callCount++;
     const sys = _options?.systemPrompt ?? '';
 
     // UIDesigner planner sub-phase
     if (sys.includes('UIPlanner') || sys.includes('planning phase of the UI designer')) {
-      return `<!-- ARTIFACT:ui-plan.json -->\n{"components": [{"name": "CompA", "file": "components/CompA.tsx", "preview": "previews/CompA.html", "purpose": "Test", "covers_flow": "main-flow", "parent": null, "children": [], "props": [], "priority": 1}]}\n<!-- END:ui-plan.json -->`;
+      return { content: `<!-- ARTIFACT:ui-plan.json -->\n{"components": [{"name": "CompA", "file": "components/CompA.tsx", "preview": "previews/CompA.html", "purpose": "Test", "covers_flow": "main-flow", "parent": null, "children": [], "props": [], "priority": 1}]}\n<!-- END:ui-plan.json -->` };
     }
     // UIDesigner builder sub-phase
     if (sys.includes('UIBuilder') || sys.includes('builder phase of the UI designer')) {
-      return `<!-- ARTIFACT:components/CompA.tsx -->\nexport default function CompA() {\n  return <div className="p-4">Test</div>;\n}\n<!-- END:components/CompA.tsx -->\n\n<!-- ARTIFACT:previews/CompA.html -->\n<!DOCTYPE html><html><head><script src="https://cdn.tailwindcss.com"></script></head><body><div class="p-4">Test</div></body></html>\n<!-- END:previews/CompA.html -->`;
+      return { content: `<!-- ARTIFACT:components/CompA.tsx -->\nexport default function CompA() {\n  return <div className="p-4">Test</div>;\n}\n<!-- END:components/CompA.tsx -->\n\n<!-- ARTIFACT:previews/CompA.html -->\n<!DOCTYPE html><html><head><script src="https://cdn.tailwindcss.com"></script></head><body><div class="p-4">Test</div></body></html>\n<!-- END:previews/CompA.html -->` };
     }
 
     const stage = STAGE_ORDER[this.callCount - 1];
@@ -30,7 +30,7 @@ class MockLLMProvider implements LLMProvider {
       validator: `<!-- ARTIFACT:validation-report.md -->\n## Validation Summary\n- Status: PASS\n- Checks passed: 4/4\n<!-- END:validation-report.md -->`,
     };
 
-    return responses[stage!] ?? '[mock] unknown stage';
+    return { content: responses[stage!] ?? '[mock] unknown stage' };
   }
 }
 

--- a/src/core/cli-progress.ts
+++ b/src/core/cli-progress.ts
@@ -1,6 +1,7 @@
 import type { StageName } from './types.js';
 import { STAGE_ORDER } from './types.js';
 import { eventBus } from './event-bus.js';
+import type { LLMUsage } from './llm-provider.js';
 
 const AGENT_LABELS: Record<StageName, string> = {
   researcher: 'Researcher',
@@ -44,12 +45,22 @@ function formatDuration(ms: number): string {
   return `${min}m${sec}s`;
 }
 
+function formatTokens(n: number): string {
+  if (n < 1000) return `${n}`;
+  return `${(n / 1000).toFixed(1)}k`;
+}
+
+function formatCost(usd: number): string {
+  return `$${usd.toFixed(2)}`;
+}
+
 function stageIndex(stage: StageName): number {
   return STAGE_ORDER.indexOf(stage) + 1;
 }
 
 export function attachCLIProgress(): () => void {
   const stageTimers = new Map<StageName, number>();
+  const stageUsage = new Map<StageName, LLMUsage>();
   const pipelineStart = Date.now();
 
   const handlers: Array<[string, (...args: any[]) => void]> = [];
@@ -72,7 +83,20 @@ export function attachCLIProgress(): () => void {
 
   on('pipeline:complete', (_runId) => {
     const elapsed = formatDuration(Date.now() - pipelineStart);
-    console.log(`\n${BOLD}${GREEN}✓ Pipeline complete${RESET} ${DIM}(${elapsed})${RESET}\n`);
+    // Sum all stage usage for total
+    let totalCost: number | undefined;
+    let totalIn = 0;
+    let totalOut = 0;
+    for (const usage of stageUsage.values()) {
+      totalIn += usage.input_tokens;
+      totalOut += usage.output_tokens;
+      if (usage.cost_usd != null) {
+        totalCost = (totalCost ?? 0) + usage.cost_usd;
+      }
+    }
+    const costPart = totalCost != null ? ` — total: ${formatCost(totalCost)}` : '';
+    const tokenPart = totalIn > 0 ? ` — in: ${formatTokens(totalIn)} / out: ${formatTokens(totalOut)}` : '';
+    console.log(`\n${BOLD}${GREEN}✓ Pipeline complete${RESET} ${DIM}(${elapsed})${tokenPart}${costPart}${RESET}\n`);
   });
 
   on('pipeline:failed', (_runId, error) => {
@@ -94,7 +118,12 @@ export function attachCLIProgress(): () => void {
   on('stage:complete', (stage, _runId) => {
     const start = stageTimers.get(stage);
     const elapsed = start ? formatDuration(Date.now() - start) : '?';
-    console.log(`  ${GREEN}✓ done${RESET} ${DIM}(${elapsed})${RESET}\n`);
+    const usage = stageUsage.get(stage);
+    const usagePart = usage
+      ? ` — in: ${formatTokens(usage.input_tokens)} / out: ${formatTokens(usage.output_tokens)} tokens` +
+        (usage.cost_usd != null ? ` — ${formatCost(usage.cost_usd)}` : '')
+      : '';
+    console.log(`  ${GREEN}✓ done${RESET} ${DIM}(${elapsed})${usagePart}${RESET}\n`);
   });
 
   on('stage:failed', (stage, _runId, error) => {
@@ -138,6 +167,12 @@ export function attachCLIProgress(): () => void {
 
   on('agent:clarification', (stage, question) => {
     console.log(`  ${YELLOW}? clarification needed:${RESET} ${question}`);
+  });
+
+  // ── Usage ──
+
+  on('agent:usage', (stage, usage) => {
+    stageUsage.set(stage, usage);
   });
 
   // ── Artifacts ──

--- a/src/core/event-bus.ts
+++ b/src/core/event-bus.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'eventemitter3';
 import type { StageName } from './types.js';
+import type { LLMUsage } from './llm-provider.js';
 
 export interface PipelineEvents {
   'stage:start': (stage: StageName, runId: string) => void;
@@ -19,6 +20,8 @@ export interface PipelineEvents {
   'agent:thinking': (stage: StageName, promptLength: number) => void;
   'agent:response': (stage: StageName, responseLength: number) => void;
   'agent:clarification': (stage: StageName, question: string) => void;
+  'agent:usage': (stage: StageName, usage: LLMUsage) => void;
+  'pipeline:usage': (totalUsage: LLMUsage) => void;
   'artifact:written': (stage: StageName, name: string, size: number) => void;
   'manifest:written': (stage: StageName, name: string) => void;
   'snapshot:created': (stage: StageName, runId: string) => void;

--- a/src/core/llm-provider.ts
+++ b/src/core/llm-provider.ts
@@ -2,12 +2,25 @@ export interface LLMCallOptions {
   systemPrompt?: string;
 }
 
+export interface LLMUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+  cost_usd?: number;
+}
+
+export interface LLMResponse {
+  content: string;
+  usage?: LLMUsage;
+}
+
 export interface LLMProvider {
-  call(prompt: string, options?: LLMCallOptions): Promise<string>;
+  call(prompt: string, options?: LLMCallOptions): Promise<LLMResponse>;
 }
 
 export class StubProvider implements LLMProvider {
-  async call(_prompt: string, _options?: LLMCallOptions): Promise<string> {
-    return '[stub] LLM response placeholder';
+  async call(_prompt: string, _options?: LLMCallOptions): Promise<LLMResponse> {
+    return { content: '[stub] LLM response placeholder' };
   }
 }

--- a/src/evolution/__tests__/engine.test.ts
+++ b/src/evolution/__tests__/engine.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
-import type { LLMProvider, LLMCallOptions } from '../../core/llm-provider.js';
+import type { LLMProvider, LLMCallOptions, LLMResponse } from '../../core/llm-provider.js';
 import { Logger } from '../../core/logger.js';
 import { EvolutionEngine } from '../engine.js';
 
@@ -10,8 +10,8 @@ const STATE_FILE = '.mosaic/evolution/state.json';
 class StubEvolutionProvider implements LLMProvider {
   response: string = '[]';
 
-  async call(_prompt: string, _options?: LLMCallOptions): Promise<string> {
-    return this.response;
+  async call(_prompt: string, _options?: LLMCallOptions): Promise<LLMResponse> {
+    return { content: this.response };
   }
 }
 
@@ -234,7 +234,7 @@ describe('EvolutionEngine', () => {
     setupArtifacts(runId);
 
     const failingProvider: LLMProvider = {
-      async call() { throw new Error('LLM unavailable'); },
+      async call(): Promise<LLMResponse> { throw new Error('LLM unavailable'); },
     };
 
     const engine = new EvolutionEngine(failingProvider, logger);

--- a/src/evolution/engine.ts
+++ b/src/evolution/engine.ts
@@ -70,11 +70,12 @@ export class EvolutionEngine {
     }
 
     // Call LLM for analysis
-    let rawResponse: string;
+    let rawContent: string;
     try {
-      rawResponse = await this.provider.call(summary, {
+      const response = await this.provider.call(summary, {
         systemPrompt: EVOLUTION_ANALYST_PROMPT,
       });
+      rawContent = response.content;
     } catch (err) {
       this.logger.pipeline('error', 'evolution:analyze:llm-error', {
         error: err instanceof Error ? err.message : String(err),
@@ -83,7 +84,7 @@ export class EvolutionEngine {
     }
 
     // Parse LLM response
-    const candidates = this.parseCandidates(rawResponse);
+    const candidates = this.parseCandidates(rawContent);
     if (candidates.length === 0) {
       this.logger.pipeline('info', 'evolution:analyze:no-proposals', { runId });
       return [];

--- a/src/mcp/__tests__/tools.test.ts
+++ b/src/mcp/__tests__/tools.test.ts
@@ -1,23 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
-import type { LLMProvider, LLMCallOptions } from '../../core/llm-provider.js';
+import type { LLMProvider, LLMCallOptions, LLMResponse } from '../../core/llm-provider.js';
 import { STAGE_ORDER } from '../../core/types.js';
 
 // Mock provider — routes UIDesigner sub-phases by system prompt
 class MockLLMProvider implements LLMProvider {
   callCount = 0;
 
-  async call(_prompt: string, _options?: LLMCallOptions): Promise<string> {
+  async call(_prompt: string, _options?: LLMCallOptions): Promise<LLMResponse> {
     this.callCount++;
     const sys = _options?.systemPrompt ?? '';
 
     // UIDesigner planner sub-phase
     if (sys.includes('UIPlanner') || sys.includes('planning phase of the UI designer')) {
-      return `<!-- ARTIFACT:ui-plan.json -->\n{"components": [{"name": "C1", "file": "components/C1.tsx", "preview": "previews/C1.html", "purpose": "Test", "covers_flow": "main", "parent": null, "children": [], "props": [], "priority": 1}]}\n<!-- END:ui-plan.json -->`;
+      return { content: `<!-- ARTIFACT:ui-plan.json -->\n{"components": [{"name": "C1", "file": "components/C1.tsx", "preview": "previews/C1.html", "purpose": "Test", "covers_flow": "main", "parent": null, "children": [], "props": [], "priority": 1}]}\n<!-- END:ui-plan.json -->` };
     }
     // UIDesigner builder sub-phase
     if (sys.includes('UIBuilder') || sys.includes('builder phase of the UI designer')) {
-      return `<!-- ARTIFACT:components/C1.tsx -->\nexport default function C1() { return <div>T</div>; }\n<!-- END:components/C1.tsx -->\n\n<!-- ARTIFACT:previews/C1.html -->\n<!DOCTYPE html><html><head><script src="https://cdn.tailwindcss.com"></script></head><body><div>T</div></body></html>\n<!-- END:previews/C1.html -->`;
+      return { content: `<!-- ARTIFACT:components/C1.tsx -->\nexport default function C1() { return <div>T</div>; }\n<!-- END:components/C1.tsx -->\n\n<!-- ARTIFACT:previews/C1.html -->\n<!DOCTYPE html><html><head><script src="https://cdn.tailwindcss.com"></script></head><body><div>T</div></body></html>\n<!-- END:previews/C1.html -->` };
     }
 
     const stageResponses: Record<string, string> = {
@@ -32,14 +32,14 @@ class MockLLMProvider implements LLMProvider {
     for (const [stage, response] of Object.entries(stageResponses)) {
       const artifactName = stage === 'researcher' ? 'research.md' : stage === 'product_owner' ? 'prd.md' : stage === 'ux_designer' ? 'ux-flows.md' : stage === 'api_designer' ? 'api-spec.yaml' : 'validation-report.md';
       if (_prompt.includes(artifactName) || sys.includes(stage.replace('_', ' '))) {
-        return response;
+        return { content: response };
       }
     }
 
     // Fallback
     const nonUIStages = STAGE_ORDER.filter((s) => s !== 'ui_designer');
     const stage = nonUIStages[this.callCount - 1];
-    return stageResponses[stage] ?? '[mock] unknown';
+    return { content: stageResponses[stage] ?? '[mock] unknown' };
   }
 }
 

--- a/src/providers/__tests__/anthropic-sdk.test.ts
+++ b/src/providers/__tests__/anthropic-sdk.test.ts
@@ -20,6 +20,8 @@ async function getMockCreate() {
   return mod.__mockCreate as ReturnType<typeof vi.fn>;
 }
 
+const MOCK_USAGE = { input_tokens: 10, output_tokens: 20 };
+
 describe('AnthropicSDKProvider', () => {
   let mockCreate: ReturnType<typeof vi.fn>;
 
@@ -31,12 +33,16 @@ describe('AnthropicSDKProvider', () => {
   it('should call messages.create with correct parameters', async () => {
     mockCreate.mockResolvedValue({
       content: [{ type: 'text', text: 'Hello world' }],
+      usage: MOCK_USAGE,
     });
 
     const provider = new AnthropicSDKProvider('test-key');
     const result = await provider.call('Say hello');
 
-    expect(result).toBe('Hello world');
+    expect(result.content).toBe('Hello world');
+    expect(result.usage).toBeDefined();
+    expect(result.usage!.input_tokens).toBe(10);
+    expect(result.usage!.output_tokens).toBe(20);
     expect(mockCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         messages: [{ role: 'user', content: 'Say hello' }],
@@ -48,6 +54,7 @@ describe('AnthropicSDKProvider', () => {
   it('should pass system prompt as native system parameter', async () => {
     mockCreate.mockResolvedValue({
       content: [{ type: 'text', text: 'I am a researcher.' }],
+      usage: MOCK_USAGE,
     });
 
     const provider = new AnthropicSDKProvider('test-key');
@@ -64,6 +71,7 @@ describe('AnthropicSDKProvider', () => {
   it('should omit system field when no system prompt provided', async () => {
     mockCreate.mockResolvedValue({
       content: [{ type: 'text', text: 'response' }],
+      usage: MOCK_USAGE,
     });
 
     const provider = new AnthropicSDKProvider('test-key');
@@ -79,12 +87,13 @@ describe('AnthropicSDKProvider', () => {
         { type: 'text', text: 'Part 1' },
         { type: 'text', text: ' Part 2' },
       ],
+      usage: MOCK_USAGE,
     });
 
     const provider = new AnthropicSDKProvider('test-key');
     const result = await provider.call('Hello');
 
-    expect(result).toBe('Part 1 Part 2');
+    expect(result.content).toBe('Part 1 Part 2');
   });
 
   it('should filter out non-text blocks', async () => {
@@ -94,12 +103,13 @@ describe('AnthropicSDKProvider', () => {
         { type: 'tool_use', id: 'x', name: 'y', input: {} },
         { type: 'text', text: ' World' },
       ],
+      usage: MOCK_USAGE,
     });
 
     const provider = new AnthropicSDKProvider('test-key');
     const result = await provider.call('Hello');
 
-    expect(result).toBe('Hello World');
+    expect(result.content).toBe('Hello World');
   });
 
   it('should propagate API errors', async () => {
@@ -112,6 +122,7 @@ describe('AnthropicSDKProvider', () => {
   it('should use custom model when provided', async () => {
     mockCreate.mockResolvedValue({
       content: [{ type: 'text', text: 'ok' }],
+      usage: MOCK_USAGE,
     });
 
     const provider = new AnthropicSDKProvider('test-key', 'claude-opus-4-20250514');
@@ -122,5 +133,19 @@ describe('AnthropicSDKProvider', () => {
         model: 'claude-opus-4-20250514',
       })
     );
+  });
+
+  it('should calculate cost based on model pricing', async () => {
+    mockCreate.mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+      usage: { input_tokens: 1000, output_tokens: 500 },
+    });
+
+    const provider = new AnthropicSDKProvider('test-key', 'claude-sonnet-4-20250514');
+    const result = await provider.call('Hello');
+
+    // sonnet-4: $3/M input, $15/M output
+    // 1000 * 3/1M + 500 * 15/1M = 0.003 + 0.0075 = 0.0105
+    expect(result.usage!.cost_usd).toBeCloseTo(0.0105, 4);
   });
 });

--- a/src/providers/anthropic-sdk.ts
+++ b/src/providers/anthropic-sdk.ts
@@ -1,8 +1,25 @@
 import Anthropic from '@anthropic-ai/sdk';
-import type { LLMProvider, LLMCallOptions } from '../core/llm-provider.js';
+import type { LLMProvider, LLMCallOptions, LLMResponse, LLMUsage } from '../core/llm-provider.js';
 
 const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
 const DEFAULT_MAX_TOKENS = 8192;
+
+// Cost per million tokens (USD) by model prefix
+const MODEL_PRICING: Record<string, { input: number; output: number }> = {
+  'claude-opus-4': { input: 15, output: 75 },
+  'claude-sonnet-4': { input: 3, output: 15 },
+  'claude-haiku-4': { input: 0.8, output: 4 },
+  'claude-3-5-sonnet': { input: 3, output: 15 },
+  'claude-3-5-haiku': { input: 0.8, output: 4 },
+  'claude-3-opus': { input: 15, output: 75 },
+};
+
+function estimateCost(model: string, usage: { input_tokens: number; output_tokens: number }): number | undefined {
+  const pricing = Object.entries(MODEL_PRICING).find(([prefix]) => model.startsWith(prefix));
+  if (!pricing) return undefined;
+  const [, rates] = pricing;
+  return (usage.input_tokens * rates.input + usage.output_tokens * rates.output) / 1_000_000;
+}
 
 export class AnthropicSDKProvider implements LLMProvider {
   private client: Anthropic;
@@ -13,7 +30,7 @@ export class AnthropicSDKProvider implements LLMProvider {
     this.model = model ?? process.env.MOSAIC_MODEL ?? DEFAULT_MODEL;
   }
 
-  async call(prompt: string, options?: LLMCallOptions): Promise<string> {
+  async call(prompt: string, options?: LLMCallOptions): Promise<LLMResponse> {
     const message = await this.client.messages.create({
       model: this.model,
       max_tokens: DEFAULT_MAX_TOKENS,
@@ -21,9 +38,19 @@ export class AnthropicSDKProvider implements LLMProvider {
       messages: [{ role: 'user', content: prompt }],
     });
 
-    return message.content
+    const content = message.content
       .filter((b): b is Anthropic.TextBlock => b.type === 'text')
       .map((b) => b.text)
       .join('');
+
+    const usage: LLMUsage = {
+      input_tokens: message.usage.input_tokens,
+      output_tokens: message.usage.output_tokens,
+      cache_creation_input_tokens: (message.usage as unknown as Record<string, number>).cache_creation_input_tokens,
+      cache_read_input_tokens: (message.usage as unknown as Record<string, number>).cache_read_input_tokens,
+      cost_usd: estimateCost(this.model, message.usage),
+    };
+
+    return { content, usage };
   }
 }

--- a/src/providers/claude-cli.ts
+++ b/src/providers/claude-cli.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import PQueue from 'p-queue';
-import type { LLMProvider, LLMCallOptions } from '../core/llm-provider.js';
+import type { LLMProvider, LLMCallOptions, LLMResponse, LLMUsage } from '../core/llm-provider.js';
 
 const TIMEOUT_MS = 600_000; // 10 minutes — complex stages (ui_designer) need time for large outputs
 const MAX_BUFFER = 10 * 1024 * 1024; // 10MB
@@ -8,15 +8,15 @@ const MAX_BUFFER = 10 * 1024 * 1024; // 10MB
 export class ClaudeCLIProvider implements LLMProvider {
   private queue = new PQueue({ concurrency: 1 });
 
-  async call(prompt: string, options?: LLMCallOptions): Promise<string> {
+  async call(prompt: string, options?: LLMCallOptions): Promise<LLMResponse> {
     return this.queue.add(async () => {
       // Prepend system prompt if provided (claude --print has no separate system prompt flag)
       const fullPrompt = options?.systemPrompt
         ? `${options.systemPrompt}\n\n---\n\n${prompt}`
         : prompt;
 
-      return new Promise<string>((resolve, reject) => {
-        const child = spawn('claude', ['--print'], {
+      return new Promise<LLMResponse>((resolve, reject) => {
+        const child = spawn('claude', ['--print', '--output-format', 'json'], {
           stdio: ['pipe', 'pipe', 'pipe'],
         });
 
@@ -49,7 +49,26 @@ export class ClaudeCLIProvider implements LLMProvider {
             reject(new Error(`Claude CLI exited with code ${code}: ${stderr.trim()}`));
             return;
           }
-          resolve(stdout.trim());
+
+          // Parse JSON output from claude --output-format json
+          try {
+            const json = JSON.parse(stdout.trim());
+            const content = json.result ?? stdout.trim();
+            const usage: LLMUsage | undefined = json.usage
+              ? {
+                  input_tokens: json.usage.input_tokens ?? 0,
+                  output_tokens: json.usage.output_tokens ?? 0,
+                  cache_creation_input_tokens: json.usage.cache_creation_input_tokens,
+                  cache_read_input_tokens: json.usage.cache_read_input_tokens,
+                  cost_usd: json.total_cost_usd ?? json.cost_usd,
+                }
+              : undefined;
+
+            resolve({ content, usage });
+          } catch {
+            // Fallback: if JSON parsing fails, treat entire output as content
+            resolve({ content: stdout.trim() });
+          }
         });
 
         child.on('error', (err) => {
@@ -61,6 +80,6 @@ export class ClaudeCLIProvider implements LLMProvider {
         child.stdin.write(fullPrompt);
         child.stdin.end();
       });
-    }) as Promise<string>;
+    }) as Promise<LLMResponse>;
   }
 }


### PR DESCRIPTION
## Summary
Closes #95

Adds token usage tracking and cost visibility throughout the pipeline. Users can now see per-stage and total token counts + estimated cost in the CLI output.

### Changes
- **LLMProvider interface**: `call()` returns `LLMResponse { content, usage? }` instead of `string`
- **LLMUsage type**: tracks `input_tokens`, `output_tokens`, cache tokens, `cost_usd`
- **ClaudeCLIProvider**: uses `--output-format json` to extract usage from Claude CLI
- **AnthropicSDKProvider**: extracts `message.usage` with model-based cost estimation
- **UIDesigner**: accumulates usage across planner + builder multi-pass calls
- **EventBus**: new `agent:usage` and `pipeline:usage` events
- **CLI progress**: displays per-stage token counts + cost, pipeline total on completion

### Steps completed
- [x] #96 — [M2-Phase 1 / Step 1] LLMUsage/LLMResponse types + LLMProvider interface change

### Test plan
- [x] `npm run build` passes
- [x] All 274 tests pass (46 test files)
- [x] All mock/stub providers updated to new return type
- [x] New test: cost calculation for AnthropicSDKProvider

:robot: Generated with [Claude Code](https://claude.com/claude-code)