### PR TITLE
M2-Phase 2: Artifact Links (T2)

### DIFF
--- a/src/core/artifact-presenter.ts
+++ b/src/core/artifact-presenter.ts
@@ -1,0 +1,75 @@
+import path from 'node:path';
+
+const ARTIFACTS_DIR = '.mosaic/artifacts';
+
+export interface ArtifactPresenter {
+  /** Format a clickable link for a single artifact */
+  formatLink(artifactName: string, size: number): string;
+  /** Format a summary line listing multiple artifacts */
+  formatSummary(artifacts: string[]): string;
+}
+
+/**
+ * OSC 8 hyperlink for terminals that support it (iTerm2, VS Code, Cursor, etc).
+ * Unsupported terminals display just the text — graceful degradation.
+ */
+function osc8Link(displayText: string, url: string): string {
+  return `\x1b]8;;${url}\x1b\\${displayText}\x1b]8;;\x1b\\`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+export class CLIArtifactPresenter implements ArtifactPresenter {
+  private baseDir: string;
+
+  constructor(baseDir?: string) {
+    this.baseDir = path.resolve(baseDir ?? ARTIFACTS_DIR);
+  }
+
+  formatLink(artifactName: string, size: number): string {
+    const absPath = path.join(this.baseDir, artifactName);
+    const linked = osc8Link(artifactName, `file://${absPath}`);
+    return `${linked} (${formatBytes(size)})`;
+  }
+
+  formatSummary(artifacts: string[]): string {
+    return artifacts
+      .map((name) => {
+        const absPath = path.join(this.baseDir, name);
+        return osc8Link(name, `file://${absPath}`);
+      })
+      .join(', ');
+  }
+}
+
+export class GitHubArtifactPresenter implements ArtifactPresenter {
+  private owner: string;
+  private repo: string;
+  private branch: string;
+  private artifactsPrefix: string;
+
+  constructor(owner: string, repo: string, branch: string, artifactsPrefix = ARTIFACTS_DIR) {
+    this.owner = owner;
+    this.repo = repo;
+    this.branch = branch;
+    this.artifactsPrefix = artifactsPrefix;
+  }
+
+  formatLink(artifactName: string, size: number): string {
+    const url = `https://github.com/${this.owner}/${this.repo}/blob/${this.branch}/${this.artifactsPrefix}/${artifactName}`;
+    return `[${artifactName}](${url}) (${formatBytes(size)})`;
+  }
+
+  formatSummary(artifacts: string[]): string {
+    return artifacts
+      .map((name) => {
+        const url = `https://github.com/${this.owner}/${this.repo}/blob/${this.branch}/${this.artifactsPrefix}/${name}`;
+        return `[${name}](${url})`;
+      })
+      .join(', ');
+  }
+}

--- a/src/core/cli-progress.ts
+++ b/src/core/cli-progress.ts
@@ -2,6 +2,7 @@ import type { StageName } from './types.js';
 import { STAGE_ORDER } from './types.js';
 import { eventBus } from './event-bus.js';
 import type { LLMUsage } from './llm-provider.js';
+import { CLIArtifactPresenter } from './artifact-presenter.js';
 
 const AGENT_LABELS: Record<StageName, string> = {
   researcher: 'Researcher',
@@ -177,8 +178,10 @@ export function attachCLIProgress(): () => void {
 
   // ── Artifacts ──
 
+  const presenter = new CLIArtifactPresenter();
+
   on('artifact:written', (stage, name, size) => {
-    console.log(`  ${CYAN}→${RESET} ${name} ${DIM}(${formatBytes(size)})${RESET}`);
+    console.log(`  ${CYAN}→${RESET} ${presenter.formatLink(name, size)}`);
   });
 
   on('manifest:written', (stage, name) => {


### PR DESCRIPTION
## Summary
Closes #98

Adds clickable artifact links in CLI output using OSC 8 terminal hyperlinks. Users can click on artifact names to open them directly in their editor/finder.

### Changes
- New `ArtifactPresenter` interface with `formatLink()` and `formatSummary()`
- `CLIArtifactPresenter`: OSC 8 `file://` hyperlinks (iTerm2, VS Code, Cursor compatible)
- `GitHubArtifactPresenter`: GitHub blob URLs for PR/issue contexts
- `cli-progress` uses presenter for `artifact:written` event display
- Graceful degradation for unsupported terminals

### Steps completed
- [x] #99 — ArtifactPresenter + OSC 8 terminal hyperlinks

### Test plan
- [x] `npm run build` passes
- [x] All 274 tests pass (46 test files)

:robot: Generated with [Claude Code](https://claude.com/claude-code)