### PR TITLE
M2-Phase 3: GitHub PR Flow (T3)

### DIFF
--- a/src/__tests__/e2e-phase4.test.ts
+++ b/src/__tests__/e2e-phase4.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import type { LLMProvider, LLMCallOptions, LLMResponse } from '../core/llm-provider.js';
 import { STAGE_ORDER } from '../core/types.js';
-import type { GitPlatformAdapter, CreateIssueParams, IssueComment, IssueDetails } from '../adapters/types.js';
+import type { GitPlatformAdapter, CreateIssueParams, IssueComment, IssueDetails, PRRef } from '../adapters/types.js';
 import type { GitHubConfig } from '../core/types.js';
 import type { SecurityConfig } from '../core/security.js';
 import { Orchestrator } from '../core/orchestrator.js';
@@ -97,6 +97,12 @@ class InMemoryGitPlatformAdapter implements GitPlatformAdapter {
       createdAt: new Date().toISOString(),
     };
   }
+
+  async createPR(params: { title: string; body: string; head: string; base?: string; draft?: boolean }): Promise<PRRef> {
+    return { number: 999, url: 'https://example.com/pulls/999', branch: params.head };
+  }
+
+  async markPRReady(_prNumber: number): Promise<void> {}
 
   addMockComment(issueNumber: number, author: string, body: string) {
     const comments = this.comments.get(issueNumber) ?? [];

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -5,6 +5,7 @@ import type {
   IssueRef,
   IssueComment,
   IssueDetails,
+  PRRef,
 } from './types.js';
 
 export class GitHubAdapter implements GitPlatformAdapter {
@@ -96,6 +97,39 @@ export class GitHubAdapter implements GitPlatformAdapter {
       closedAt: data.closed_at ?? undefined,
     };
   }
+  async createPR(params: { title: string; body: string; head: string; base?: string; draft?: boolean }): Promise<PRRef> {
+    const { data } = await this.octokit.pulls.create({
+      owner: this.owner,
+      repo: this.repo,
+      title: params.title,
+      body: params.body,
+      head: params.head,
+      base: params.base ?? 'main',
+      draft: params.draft ?? false,
+    });
+    return { number: data.number, url: data.html_url, branch: params.head };
+  }
+
+  async markPRReady(prNumber: number): Promise<void> {
+    // GitHub REST API doesn't support marking as ready — use GraphQL
+    const { data: pr } = await this.octokit.pulls.get({
+      owner: this.owner,
+      repo: this.repo,
+      pull_number: prNumber,
+    });
+    if (pr.draft) {
+      await this.octokit.graphql(`
+        mutation($id: ID!) {
+          markPullRequestReadyForReview(input: { pullRequestId: $id }) {
+            pullRequest { id }
+          }
+        }
+      `, { id: pr.node_id });
+    }
+  }
+
+  getOwner(): string { return this.owner; }
+  getRepo(): string { return this.repo; }
 }
 
 export function createGitHubAdapter(): GitHubAdapter {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -26,6 +26,12 @@ export interface IssueDetails {
   closedAt?: string;
 }
 
+export interface PRRef {
+  number: number;
+  url: string;
+  branch: string;
+}
+
 export interface GitPlatformAdapter {
   createIssue(params: CreateIssueParams): Promise<IssueRef>;
   addComment(issueNumber: number, body: string): Promise<void>;
@@ -34,4 +40,6 @@ export interface GitPlatformAdapter {
   removeLabel(issueNumber: number, label: string): Promise<void>;
   getComments(issueNumber: number, since?: string): Promise<IssueComment[]>;
   getIssue(issueNumber: number): Promise<IssueDetails>;
+  createPR(params: { title: string; body: string; head: string; base?: string; draft?: boolean }): Promise<PRRef>;
+  markPRReady(prNumber: number): Promise<void>;
 }

--- a/src/core/__tests__/github-interaction-handler.test.ts
+++ b/src/core/__tests__/github-interaction-handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { GitHubInteractionHandler } from '../github-interaction-handler.js';
-import type { GitPlatformAdapter, CreateIssueParams, IssueComment, IssueDetails } from '../../adapters/types.js';
+import type { GitPlatformAdapter, CreateIssueParams, IssueComment, IssueDetails, PRRef } from '../../adapters/types.js';
 import type { GitHubConfig } from '../types.js';
 import type { SecurityConfig } from '../security.js';
 
@@ -65,6 +65,12 @@ class InMemoryAdapter implements GitPlatformAdapter {
       createdAt: new Date().toISOString(),
     };
   }
+
+  async createPR(params: { title: string; body: string; head: string; base?: string; draft?: boolean }): Promise<PRRef> {
+    return { number: 999, url: 'https://example.com/pulls/999', branch: params.head };
+  }
+
+  async markPRReady(_prNumber: number): Promise<void> {}
 
   // Test helper: simulate a user comment
   simulateComment(issueNumber: number, author: string, body: string) {

--- a/src/core/git-publisher.ts
+++ b/src/core/git-publisher.ts
@@ -1,0 +1,88 @@
+import { execFileSync } from 'node:child_process';
+import type { GitPlatformAdapter, PRRef } from '../adapters/types.js';
+import { eventBus } from './event-bus.js';
+
+function git(...args: string[]): string {
+  return execFileSync('git', args, { encoding: 'utf-8' }).trim();
+}
+
+export class GitPublisher {
+  private adapter: GitPlatformAdapter;
+  private branch: string | null = null;
+  private prRef: PRRef | null = null;
+
+  constructor(adapter: GitPlatformAdapter) {
+    this.adapter = adapter;
+  }
+
+  /** Create branch and Draft PR at pipeline start. Returns branch name. */
+  async init(runId: string, title: string): Promise<string> {
+    const timestamp = runId.replace('run-', '');
+    this.branch = `mosaicat/run-${timestamp}`;
+
+    // Create and push branch
+    git('checkout', '-b', this.branch);
+    // Create an initial empty commit so the branch exists on remote
+    git('commit', '--allow-empty', '-m', `chore: init pipeline ${runId}`);
+    git('push', '-u', 'origin', this.branch);
+
+    // Create Draft PR
+    this.prRef = await this.adapter.createPR({
+      title: `[Mosaicat] ${title}`,
+      body: `## Pipeline Run: ${runId}\n\n_Pipeline in progress..._`,
+      head: this.branch,
+      draft: true,
+    });
+
+    return this.branch;
+  }
+
+  /** Commit stage artifacts and push */
+  async commitStage(stage: string, files: string[], issueNumber?: number): Promise<void> {
+    if (!this.branch) return;
+
+    // Stage files
+    for (const file of files) {
+      try {
+        git('add', file);
+      } catch {
+        // File may not exist (e.g. screenshots skipped)
+      }
+    }
+
+    // Check if there's anything to commit
+    try {
+      git('diff', '--cached', '--quiet');
+      // No changes staged
+      return;
+    } catch {
+      // Changes exist — proceed with commit
+    }
+
+    const issueRef = issueNumber ? ` (#${issueNumber})` : '';
+    git('commit', '-m', `feat(${stage}): add ${stage} artifacts${issueRef}`);
+    git('push', 'origin', this.branch);
+  }
+
+  /** Update PR body and mark ready for review at pipeline end */
+  async publish(prBody: string): Promise<PRRef | null> {
+    if (!this.prRef) return null;
+
+    // Update PR body — use issue comment since REST can't update body easily
+    // Actually, we can update via addComment on the PR (PRs are issues in GitHub)
+    await this.adapter.addComment(this.prRef.number, prBody);
+
+    // Mark as ready for review
+    await this.adapter.markPRReady(this.prRef.number);
+
+    return this.prRef;
+  }
+
+  getBranch(): string | null {
+    return this.branch;
+  }
+
+  getPR(): PRRef | null {
+    return this.prRef;
+  }
+}

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -19,12 +19,14 @@ import type { InteractionHandler } from './interaction-handler.js';
 import { CLIInteractionHandler } from './interaction-handler.js';
 import type { GitPlatformAdapter } from '../adapters/types.js';
 import { buildIssueBody } from './security.js';
+import { GitPublisher } from './git-publisher.js';
 
 export class Orchestrator {
   private pipelineConfig: PipelineConfig;
   private agentsConfig: AgentsConfig;
   private handler: InteractionHandler;
   private adapter?: GitPlatformAdapter;
+  private publisher?: GitPublisher;
   private stageIssues = new Map<string, number>();
 
   constructor(handler?: InteractionHandler, adapter?: GitPlatformAdapter) {
@@ -47,9 +49,38 @@ export class Orchestrator {
     logger.pipeline('info', 'pipeline:start', { runId, instruction });
     eventBus.emit('pipeline:start', runId);
 
+    // Initialize GitPublisher for GitHub mode
+    if (this.adapter) {
+      this.publisher = new GitPublisher(this.adapter);
+      try {
+        await this.publisher.init(runId, instruction.slice(0, 80));
+      } catch (err) {
+        // Git publisher init failure is non-fatal — continue without it
+        logger.pipeline('warn', 'git-publisher:init-failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        this.publisher = undefined;
+      }
+    }
+
     try {
       for (const stage of STAGE_ORDER) {
         await this.executeStage(pipelineRun, stage, provider, logger);
+
+        // Commit stage artifacts to PR branch
+        if (this.publisher) {
+          try {
+            const agentConfig = this.agentsConfig.agents[stage];
+            const files = (agentConfig.outputs ?? []).map((o: string) => `.mosaic/artifacts/${o}`);
+            const issueNumber = this.stageIssues.get(`${runId}:${stage}`);
+            await this.publisher.commitStage(stage, files, issueNumber);
+          } catch (err) {
+            logger.pipeline('warn', 'git-publisher:commit-failed', {
+              stage,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
       }
 
       // Post-run evolution analysis
@@ -59,6 +90,18 @@ export class Orchestrator {
 
       pipelineRun.completedAt = new Date().toISOString();
       await this.createSummaryIssue(runId);
+
+      // Publish PR (mark ready for review)
+      if (this.publisher) {
+        try {
+          await this.publisher.publish(`## Pipeline Complete\n\nRun: ${runId}`);
+        } catch (err) {
+          logger.pipeline('warn', 'git-publisher:publish-failed', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
       logger.pipeline('info', 'pipeline:complete', { runId });
       eventBus.emit('pipeline:complete', runId);
     } catch (err) {


### PR DESCRIPTION
## Summary
Closes #101

Adds GitHub PR workflow: pipeline creates a Draft PR at start, commits artifacts after each stage, and marks PR ready at pipeline end.

### Changes
- **GitPlatformAdapter**: new `createPR()`, `markPRReady()` + `PRRef` type
- **GitHubAdapter**: Octokit `pulls.create` + GraphQL `markPullRequestReadyForReview`
- **GitPublisher**: `init()` creates branch + Draft PR, `commitStage()` per-stage commit, `publish()` marks ready
- **Orchestrator**: GitHub mode integration — non-fatal git operations

### Steps completed
- [x] #102 — GitPlatformAdapter extensions + GitPublisher

### Test plan
- [x] `npm run build` passes
- [x] Targeted tests pass (e2e-phase4, github-interaction-handler)

:robot: Generated with [Claude Code](https://claude.com/claude-code)