### PR TITLE
M2-Phase 5: Issue Hierarchy + Step Modularity (T4)

### DIFF
--- a/.claude/agents/mosaic/ui-planner.md
+++ b/.claude/agents/mosaic/ui-planner.md
@@ -43,6 +43,11 @@ If the PRD already specifies design preferences, skip clarification.
     "border": "gray-200",
     "radius": "rounded-xl"
   },
+  "modules": [
+    { "name": "atomic", "label": "基础原子组件", "components": ["TaskInput", "Checkbox"] },
+    { "name": "business", "label": "业务组件", "components": ["TaskList", "TaskItem"] },
+    { "name": "pages", "label": "页面级组件", "components": ["App"] }
+  ],
   "components": [
     {
       "name": "TaskInput",
@@ -70,6 +75,7 @@ If the PRD already specifies design preferences, skip clarification.
 - **props**: TypeScript-style prop signatures
 - **priority**: Build order (1 = build first, higher = later). Leaf components first, containers last.
 - **design_tokens**: Optional design token overrides (when user specifies custom style)
+- **modules**: Optional grouping of components into build modules (atomic → business → pages). This helps organize step-level tracking and partial rebuilds.
 
 ## Guidelines
 

--- a/src/agents/ui-plan-schema.ts
+++ b/src/agents/ui-plan-schema.ts
@@ -12,8 +12,15 @@ export const UIPlanComponentSchema = z.object({
   priority: z.number(),
 });
 
+export const UIPlanModuleSchema = z.object({
+  name: z.string(),       // e.g. "atomic", "business", "pages"
+  label: z.string(),      // e.g. "基础原子组件", "业务组件"
+  components: z.array(z.string()), // component names in this module
+});
+
 export const UIPlanSchema = z.object({
   design_tokens: z.record(z.string(), z.string()).optional(),
+  modules: z.array(UIPlanModuleSchema).optional(),
   components: z.array(UIPlanComponentSchema),
 });
 

--- a/src/core/issue-manager.ts
+++ b/src/core/issue-manager.ts
@@ -1,0 +1,116 @@
+import type { GitPlatformAdapter, IssueRef } from '../adapters/types.js';
+import type { StageName } from './types.js';
+import type { LLMUsage } from './llm-provider.js';
+import { eventBus } from './event-bus.js';
+
+export interface StepInfo {
+  name: string;
+  label: string;
+  status: 'pending' | 'running' | 'done' | 'failed';
+  issueNumber?: number;
+}
+
+export class IssueManager {
+  private adapter: GitPlatformAdapter;
+  private stageIssues = new Map<string, number>(); // "runId:stage" → issue#
+  private stepIssues = new Map<string, number>();   // "runId:stage:step" → issue#
+
+  constructor(adapter: GitPlatformAdapter) {
+    this.adapter = adapter;
+  }
+
+  /** Create a stage-level issue (e.g., [UIDesigner] React components) */
+  async createStageIssue(
+    stage: StageName,
+    runId: string,
+    description: string,
+    steps?: StepInfo[],
+  ): Promise<IssueRef> {
+    const stepsTable = steps
+      ? '\n\n### Steps\n' + steps.map((s) =>
+          `| ${s.status === 'done' ? ':white_check_mark:' : ':hourglass:'} | ${s.label} | ${s.status} |`
+        ).join('\n')
+      : '';
+
+    const issue = await this.adapter.createIssue({
+      title: `[${stage}] ${description}`,
+      body: `## Stage: ${stage}\n\n**Run:** ${runId}\n${stepsTable}`,
+      labels: ['mosaicat:auto', 'mosaicat:stage', `agent:${stage}`],
+    });
+
+    this.stageIssues.set(`${runId}:${stage}`, issue.number);
+    eventBus.emit('issue:created', issue.number, stage, runId);
+    return issue;
+  }
+
+  /** Create a step-level issue under a stage issue */
+  async createStepIssue(
+    stage: StageName,
+    runId: string,
+    stepName: string,
+    stepLabel: string,
+  ): Promise<IssueRef> {
+    const stageIssueNum = this.stageIssues.get(`${runId}:${stage}`);
+    const parentRef = stageIssueNum ? `\n\nParent: #${stageIssueNum}` : '';
+
+    const issue = await this.adapter.createIssue({
+      title: `[${stage}/${stepName}] ${stepLabel}`,
+      body: `## Step: ${stepLabel}${parentRef}\n\n**Run:** ${runId}`,
+      labels: ['mosaicat:auto', 'mosaicat:step', `agent:${stage}`],
+    });
+
+    this.stepIssues.set(`${runId}:${stage}:${stepName}`, issue.number);
+    return issue;
+  }
+
+  /** Update stage issue body with step statuses and usage */
+  async updateStageIssue(
+    stage: StageName,
+    runId: string,
+    steps: StepInfo[],
+    usage?: LLMUsage,
+  ): Promise<void> {
+    const issueNumber = this.stageIssues.get(`${runId}:${stage}`);
+    if (!issueNumber) return;
+
+    const stepsTable = steps.map((s) => {
+      const icon = s.status === 'done' ? ':white_check_mark:'
+        : s.status === 'running' ? ':hourglass:'
+        : s.status === 'failed' ? ':x:'
+        : ':black_circle:';
+      const issueRef = s.issueNumber ? ` #${s.issueNumber}` : '';
+      return `- ${icon} **${s.label}**${issueRef} — ${s.status}`;
+    }).join('\n');
+
+    const usageLine = usage
+      ? `\n\n**Usage:** in: ${usage.input_tokens} / out: ${usage.output_tokens} tokens` +
+        (usage.cost_usd != null ? ` — $${usage.cost_usd.toFixed(2)}` : '')
+      : '';
+
+    await this.adapter.addComment(issueNumber, `### Step Progress\n${stepsTable}${usageLine}`);
+  }
+
+  /** Close a step issue */
+  async closeStepIssue(stage: StageName, runId: string, stepName: string): Promise<void> {
+    const issueNumber = this.stepIssues.get(`${runId}:${stage}:${stepName}`);
+    if (!issueNumber) return;
+    await this.adapter.closeIssue(issueNumber);
+  }
+
+  /** Close a stage issue */
+  async closeStageIssue(stage: StageName, runId: string): Promise<void> {
+    const issueNumber = this.stageIssues.get(`${runId}:${stage}`);
+    if (!issueNumber) return;
+    await this.adapter.addLabels(issueNumber, ['status:completed']);
+    await this.adapter.closeIssue(issueNumber);
+    eventBus.emit('issue:closed', issueNumber, stage, runId);
+  }
+
+  getStageIssueNumber(stage: StageName, runId: string): number | undefined {
+    return this.stageIssues.get(`${runId}:${stage}`);
+  }
+
+  getAllStageIssues(): Map<string, number> {
+    return new Map(this.stageIssues);
+  }
+}


### PR DESCRIPTION
## Summary
Closes #108

Adds stage/step issue hierarchy and component module grouping for better pipeline observability.

### Changes
- **UIPlan schema**: optional `modules[]` field for grouping components (atomic/business/pages)
- **ui-planner.md**: prompt requests modules output
- **IssueManager**: stage-level and step-level issue lifecycle with progress tracking

### Steps completed
- [x] #109 — UIPlan modules + IssueManager

### Test plan
- [x] `npm run build` passes

:robot: Generated with [Claude Code](https://claude.com/claude-code)