### PR TITLE
feat: Pipeline Profile + conditional skip (Phase 4)

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -42,6 +42,37 @@ stages:
     gate: manual
     retry_max: 3
 
+profiles:
+  design-only:
+    - intent_consultant
+    - researcher
+    - product_owner
+    - ux_designer
+    - api_designer
+    - ui_designer
+    - validator
+  full:
+    - intent_consultant
+    - researcher
+    - product_owner
+    - ux_designer
+    - api_designer
+    - ui_designer
+    - tech_lead
+    - coder
+    - reviewer
+    - validator
+  frontend-only:
+    - intent_consultant
+    - researcher
+    - product_owner
+    - ux_designer
+    - ui_designer
+    - tech_lead
+    - coder
+    - reviewer
+    - validator
+
 pipeline:
   max_retries_per_stage: 3
   snapshot: on_stage_complete

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import yaml from 'js-yaml';
-import type { PipelineConfig, AgentsConfig, StageName, PipelineRun, AgentContext } from './types.js';
+import type { PipelineConfig, AgentsConfig, StageName, PipelineRun, AgentContext, PipelineProfile } from './types.js';
 import { STAGE_ORDER, ClarificationNeeded } from './types.js';
 import {
   createPipelineRun,
@@ -70,13 +70,17 @@ export class Orchestrator {
     this.adapter = adapter;
   }
 
-  async run(instruction: string, autoApprove = false): Promise<PipelineRun> {
+  async run(instruction: string, autoApprove = false, profile?: PipelineProfile): Promise<PipelineRun> {
     const runId = `run-${Date.now()}`;
-    const pipelineRun = createPipelineRun(runId, instruction, autoApprove);
+
+    // Resolve stage list from profile
+    const stageList = this.resolveStageList(profile);
+
+    const pipelineRun = createPipelineRun(runId, instruction, autoApprove, stageList);
     const logger = new Logger(runId);
     const provider = createProvider();
 
-    logger.pipeline('info', 'pipeline:start', { runId, instruction });
+    logger.pipeline('info', 'pipeline:start', { runId, instruction, profile: profile ?? 'default' });
     eventBus.emit('pipeline:start', runId);
 
     // Initialize GitPublisher for GitHub mode
@@ -97,7 +101,9 @@ export class Orchestrator {
       // Intent Consultant: multi-turn dialogue before pipeline
       await this.runIntentConsultant(pipelineRun, provider, logger);
 
-      for (const stage of STAGE_ORDER) {
+      // Filter stage list: skip intent_consultant (handled above)
+      const pipelineStages = stageList.filter((s) => s !== 'intent_consultant');
+      for (const stage of pipelineStages) {
         await this.executeStage(pipelineRun, stage, provider, logger);
       }
 
@@ -140,6 +146,15 @@ export class Orchestrator {
     }
 
     return pipelineRun;
+  }
+
+  private resolveStageList(profile?: PipelineProfile): readonly StageName[] {
+    if (!profile) return STAGE_ORDER;
+    const profiles = this.pipelineConfig.profiles;
+    if (!profiles || !profiles[profile]) {
+      throw new Error(`Unknown pipeline profile: ${profile}. Available: ${profiles ? Object.keys(profiles).join(', ') : 'none'}`);
+    }
+    return profiles[profile];
   }
 
   private async executeStage(

--- a/src/core/pipeline.ts
+++ b/src/core/pipeline.ts
@@ -1,9 +1,14 @@
 import type { StageName, StageState, StageStatus, PipelineRun, StageConfig } from './types.js';
 import { STAGE_ORDER } from './types.js';
 
-export function createPipelineRun(id: string, instruction: string, autoApprove: boolean): PipelineRun {
-  const stages = {} as Record<StageName, StageStatus>;
-  for (const name of STAGE_ORDER) {
+export function createPipelineRun(
+  id: string,
+  instruction: string,
+  autoApprove: boolean,
+  stageNames?: readonly StageName[],
+): PipelineRun {
+  const stages: Partial<Record<StageName, StageStatus>> = {};
+  for (const name of (stageNames ?? STAGE_ORDER)) {
     stages[name] = { state: 'idle', retryCount: 0 };
   }
 

--- a/src/core/run-manager.ts
+++ b/src/core/run-manager.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import yaml from 'js-yaml';
-import type { StageName, PipelineRun, PipelineConfig, ClarificationOption } from './types.js';
+import type { StageName, PipelineRun, PipelineConfig, PipelineProfile, ClarificationOption } from './types.js';
 import { Orchestrator } from './orchestrator.js';
 import { DeferredInteractionHandler } from './interaction-handler.js';
 import type { InteractionHandler } from './interaction-handler.js';
@@ -43,7 +43,7 @@ interface ManagedRun {
 export class RunManager {
   private runs = new Map<string, ManagedRun>();
 
-  async startRun(instruction: string, autoApprove = false): Promise<string> {
+  async startRun(instruction: string, autoApprove = false, profile?: PipelineProfile): Promise<string> {
     const id = `managed-${Date.now()}`;
 
     const pipelineConfig = yaml.load(
@@ -85,7 +85,7 @@ export class RunManager {
     };
 
     managedRun.promise = orchestrator
-      .run(instruction, autoApprove)
+      .run(instruction, autoApprove, profile)
       .then((result) => {
         managedRun.pipelineRun = result;
         managedRun.state = 'completed';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -89,8 +89,11 @@ export interface EvolutionConfig {
   cooldown_hours: number;
 }
 
+export type PipelineProfile = 'design-only' | 'full' | 'frontend-only';
+
 export interface PipelineConfig {
   stages: Partial<Record<StageName, StageConfig>>;
+  profiles?: Record<PipelineProfile, StageName[]>;
   pipeline: {
     max_retries_per_stage: number;
     snapshot: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,13 +39,15 @@ if (command === 'login') {
 } else if (command === 'run') {
   const instruction = args[1];
   if (!instruction) {
-    console.error('Usage: mosaicat run <instruction> [--auto-approve] [--github] [--evolve]');
+    console.error('Usage: mosaicat run <instruction> [--auto-approve] [--github] [--evolve] [--profile <design-only|full|frontend-only>]');
     process.exit(1);
   }
 
   const autoApprove = args.includes('--auto-approve');
   const useGitHub = args.includes('--github');
   const useEvolve = args.includes('--evolve');
+  const profileIdx = args.indexOf('--profile');
+  const profileArg = profileIdx >= 0 ? args[profileIdx + 1] as import('./core/types.js').PipelineProfile | undefined : undefined;
 
   // Attach rich CLI progress output
   const detach = attachCLIProgress();
@@ -83,8 +85,9 @@ if (command === 'login') {
 
     console.log(`\x1b[2mInstruction: ${instruction}\x1b[0m`);
     console.log(`\x1b[2mAuto-approve: ${autoApprove}\x1b[0m`);
+    if (profileArg) console.log(`\x1b[2mProfile: ${profileArg}\x1b[0m`);
 
-    const result = await orchestrator.run(instruction, autoApprove);
+    const result = await orchestrator.run(instruction, autoApprove, profileArg);
 
     console.log(`\x1b[2mRun ID: ${result.id}\x1b[0m`);
     console.log(`\x1b[2mArtifacts: .mosaic/artifacts/\x1b[0m`);

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -21,9 +21,10 @@ export function registerTools(server: McpServer, runManager: RunManager): void {
     {
       instruction: z.string().describe('The product idea or instruction to process through the pipeline'),
       auto_approve: z.boolean().optional().describe('Skip manual approval gates (default: false)'),
+      profile: z.enum(['design-only', 'full', 'frontend-only']).optional().describe('Pipeline profile (default: design-only)'),
     },
-    async ({ instruction, auto_approve }) => {
-      const runId = await runManager.startRun(instruction, auto_approve ?? false);
+    async ({ instruction, auto_approve, profile }) => {
+      const runId = await runManager.startRun(instruction, auto_approve ?? false, profile);
       return {
         content: [{
           type: 'text' as const,


### PR DESCRIPTION
## Summary
Closes #166

Adds pipeline profile support (`design-only` / `full` / `frontend-only`) that controls which stages execute. Profiles are defined in `pipeline.yaml` and selected via `--profile` CLI flag or MCP `mosaic_run` parameter. Stages not in the active profile are skipped. The validator already handles missing manifests from skipped stages gracefully.

### Steps completed
- [x] #167 — Profile definition + orchestrator profile support + validator adaptation

### Key changes
- `config/pipeline.yaml`: profiles block with stage lists per profile
- `PipelineProfile` type + `PipelineConfig.profiles` field
- `createPipelineRun()` accepts `stageNames` for sparse stage maps
- `Orchestrator.run()` accepts profile, resolves stage list via `resolveStageList()`
- CLI `--profile` flag, MCP `mosaic_run` profile parameter
- `RunManager` passes profile through to orchestrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)