### PR TITLE
feat: Evolution system upgrade — stage-level + Agent Skills standard (Phase 5)

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -267,6 +267,11 @@ export class Orchestrator {
 
       logger.pipeline('info', 'stage:complete', { stage });
       eventBus.emit('stage:complete', stage, run.id);
+
+      // Stage-level evolution analysis (non-blocking)
+      if (this.pipelineConfig.evolution?.enabled) {
+        await this.runStageEvolution(run.id, stage, provider, logger);
+      }
     } catch (err) {
       // ClarificationNeeded is handled inside executeAgent, not here
       const message = err instanceof Error ? err.message : String(err);
@@ -586,6 +591,32 @@ export class Orchestrator {
       this.pipelineConfig.evolution = { enabled: true, cooldown_hours: 24 };
     } else {
       this.pipelineConfig.evolution.enabled = true;
+    }
+  }
+
+  private async runStageEvolution(
+    runId: string,
+    stage: StageName,
+    provider: LLMProvider,
+    logger: Logger,
+  ): Promise<void> {
+    try {
+      const { EvolutionEngine } = await import('../evolution/engine.js');
+      const { ProposalHandler } = await import('../evolution/proposal-handler.js');
+
+      const engine = new EvolutionEngine(provider, logger);
+      const proposals = await engine.analyzeStage(runId, stage);
+
+      if (proposals.length > 0) {
+        const handler = new ProposalHandler(this.handler, provider, logger);
+        await handler.processProposals(proposals);
+      }
+    } catch (err) {
+      logger.pipeline('error', 'evolution:stage-error', {
+        stage,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Stage evolution errors don't fail the pipeline
     }
   }
 

--- a/src/evolution/engine.ts
+++ b/src/evolution/engine.ts
@@ -58,6 +58,28 @@ export class EvolutionEngine {
     this.logger = logger;
   }
 
+  /**
+   * Analyze a single stage's output for evolution proposals.
+   * Called after each stage completes (stage-level evolution).
+   */
+  async analyzeStage(runId: string, stage: StageName): Promise<EvolutionProposal[]> {
+    this.logger.pipeline('info', 'evolution:analyze-stage:start', { runId, stage });
+
+    const state = this.loadState();
+    const summary = this.buildStageSummary(stage);
+
+    if (!summary) {
+      this.logger.pipeline('info', 'evolution:analyze-stage:no-data', { runId, stage });
+      return [];
+    }
+
+    return this.runAnalysis(runId, summary, state);
+  }
+
+  /**
+   * Analyze the full pipeline run for evolution proposals.
+   * Called after pipeline completes (pipeline-level evolution).
+   */
   async analyze(runId: string): Promise<EvolutionProposal[]> {
     this.logger.pipeline('info', 'evolution:analyze:start', { runId });
 
@@ -69,6 +91,14 @@ export class EvolutionEngine {
       return [];
     }
 
+    return this.runAnalysis(runId, summary, state);
+  }
+
+  private async runAnalysis(
+    runId: string,
+    summary: string,
+    state: EvolutionState,
+  ): Promise<EvolutionProposal[]> {
     // Call LLM for analysis
     let rawContent: string;
     try {
@@ -150,6 +180,37 @@ export class EvolutionEngine {
   saveState(state: EvolutionState): void {
     ensureDir(STATE_DIR);
     fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+  }
+
+  private buildStageSummary(stage: StageName): string | null {
+    const parts: string[] = [];
+    const artifactsDir = '.mosaic/artifacts';
+
+    if (!fs.existsSync(artifactsDir)) return null;
+
+    // Find manifests and artifacts for this stage
+    const stageArtifactMap: Record<string, string[]> = {
+      researcher: ['research.md', 'research.manifest.json'],
+      product_owner: ['prd.md', 'prd.manifest.json'],
+      ux_designer: ['ux-flows.md', 'ux-flows.manifest.json'],
+      api_designer: ['api-spec.yaml', 'api-spec.manifest.json'],
+      ui_designer: ['components.manifest.json'],
+      validator: ['validation-report.md'],
+    };
+
+    const files = stageArtifactMap[stage] ?? [];
+    for (const file of files) {
+      const filePath = path.join(artifactsDir, file);
+      if (fs.existsSync(filePath)) {
+        const content = fs.readFileSync(filePath, 'utf-8');
+        parts.push(`## ${file}\n${content}`);
+      }
+    }
+
+    if (parts.length === 0) return null;
+
+    parts.unshift(`# Stage Analysis: ${stage}`);
+    return parts.join('\n\n');
   }
 
   private buildPipelineSummary(runId: string): string | null {

--- a/src/evolution/skill-manager.ts
+++ b/src/evolution/skill-manager.ts
@@ -63,8 +63,24 @@ export function persistSkill(proposal: EvolutionProposal): SkillInfo {
 
   ensureDir(scopeDir);
 
-  const filePath = path.join(scopeDir, `${name}.md`);
-  fs.writeFileSync(filePath, proposal.proposedContent);
+  // Write SKILL.md with YAML frontmatter (Agent Skills open standard)
+  const skillDir = path.join(scopeDir, name);
+  ensureDir(skillDir);
+  const filePath = path.join(skillDir, 'SKILL.md');
+
+  const frontmatter = [
+    '---',
+    `name: ${name}`,
+    `description: ${proposal.skillMetadata.description}`,
+    `scope: ${scope}`,
+    `agent: ${proposal.agentStage}`,
+    `created: ${new Date().toISOString()}`,
+    `proposal: ${proposal.id}`,
+    '---',
+    '',
+  ].join('\n');
+
+  fs.writeFileSync(filePath, frontmatter + proposal.proposedContent);
 
   const skillInfo: SkillInfo = {
     name,
@@ -102,7 +118,10 @@ export function loadSkillsForAgent(stage: StageName): Map<string, string> {
 
   for (const skill of skills) {
     if (fs.existsSync(skill.filePath)) {
-      result.set(skill.name, fs.readFileSync(skill.filePath, 'utf-8'));
+      const raw = fs.readFileSync(skill.filePath, 'utf-8');
+      // Strip YAML frontmatter if present
+      const content = raw.replace(/^---\n[\s\S]*?\n---\n*/, '');
+      result.set(skill.name, content);
     }
   }
 


### PR DESCRIPTION
## Summary
Closes #169

Upgrades the evolution system from pipeline-level to stage-level analysis and aligns skill format to the Agent Skills open standard (SKILL.md + YAML frontmatter).

### Steps completed
- [x] #170 — Stage-level evolution + Skill format upgrade

### Key changes
- `EvolutionEngine.analyzeStage()`: single-stage analysis mode with `buildStageSummary()`
- Extracted `runAnalysis()` helper for shared LLM analysis logic
- Orchestrator calls `runStageEvolution()` after each stage completes (non-blocking)
- Skills now stored as `SKILL.md` with YAML frontmatter in per-skill directories
- `loadSkillsForAgent()` strips frontmatter when loading skill content

🤖 Generated with [Claude Code](https://claude.com/claude-code)