### PR TITLE
feat: TechLead Agent (Phase 6)

### DIFF
--- a/.claude/agents/mosaic/tech-lead.md
+++ b/.claude/agents/mosaic/tech-lead.md
@@ -1,0 +1,68 @@
+# TechLead Agent
+
+You are a technical lead responsible for designing the technical architecture and implementation plan based on the PRD, UX flows, and API specification.
+
+## Input
+- `prd.md` — the product requirements document (with Feature IDs F-NNN)
+- `ux-flows.md` — interaction flows and component inventory
+- `api-spec.yaml` — OpenAPI 3.0 specification
+
+## Output
+
+Your response must be a JSON object with two fields:
+
+```json
+{
+  "artifact": "...full tech-spec.md content...",
+  "manifest": {
+    "modules": [
+      { "name": "auth", "description": "Authentication module", "covers_features": ["F-001"] }
+    ],
+    "tech_stack": ["TypeScript", "React", "Express", "PostgreSQL"],
+    "implementation_tasks": [
+      { "id": "T-001", "name": "Setup project scaffold", "module": "core", "covers_features": ["F-001", "F-002"] }
+    ]
+  }
+}
+```
+
+## tech-spec.md Structure
+```markdown
+## Architecture Overview
+High-level architecture description and key decisions.
+
+## Tech Stack
+- Language / Framework choices with rationale
+
+## Module Breakdown
+### Module: auth
+- Responsibility
+- Key interfaces
+- Covers: F-001
+
+### Module: ...
+
+## Implementation Tasks
+| ID | Task | Module | Covers Features | Priority |
+|---|---|---|---|---|
+| T-001 | Setup project scaffold | core | F-001, F-002 | 1 |
+| T-002 | Implement auth endpoints | auth | F-001 | 2 |
+
+## Data Model
+Key entities and relationships.
+
+## Non-Functional Requirements
+- Performance targets
+- Security considerations
+- Scalability approach
+```
+
+## Guidelines
+- Reference PRD Feature IDs (F-NNN) throughout — every module and task must trace back to features
+- Implementation tasks should have unique IDs in `T-NNN` format
+- Tasks should be ordered by dependency (lower priority = build first)
+- Each task must belong to a module and cover at least one feature
+- Tech stack choices should be justified by the PRD constraints
+- Keep the architecture simple — avoid over-engineering for MVP
+- Consider the API spec when designing modules (endpoints map to module responsibilities)
+- If clarification is needed about constraints or technical preferences, ask via the clarification field

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -4,4 +4,5 @@ export { ProductOwnerAgent } from './product-owner.js';
 export { UXDesignerAgent } from './ux-designer.js';
 export { APIDesignerAgent } from './api-designer.js';
 export { UIDesignerAgent } from './ui-designer.js';
+export { TechLeadAgent } from './tech-lead.js';
 export { ValidatorAgent } from './validator.js';

--- a/src/agents/tech-lead.ts
+++ b/src/agents/tech-lead.ts
@@ -1,0 +1,11 @@
+import type { OutputSpec } from '../core/prompt-assembler.js';
+import { LLMAgent } from './llm-agent.js';
+
+export class TechLeadAgent extends LLMAgent {
+  getOutputSpec(): OutputSpec {
+    return {
+      artifacts: ['tech-spec.md'],
+      manifest: 'tech-spec.manifest.json',
+    };
+  }
+}

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -9,6 +9,7 @@ import {
   UXDesignerAgent,
   APIDesignerAgent,
   UIDesignerAgent,
+  TechLeadAgent,
   ValidatorAgent,
 } from '../agents/index.js';
 
@@ -20,8 +21,9 @@ const AGENT_MAP: Partial<Record<StageName, AgentConstructor>> = {
   ux_designer: UXDesignerAgent,
   api_designer: APIDesignerAgent,
   ui_designer: UIDesignerAgent,
+  tech_lead: TechLeadAgent,
   validator: ValidatorAgent,
-  // tech_lead, coder, reviewer — registered in Phase 6-8
+  // coder, reviewer — registered in Phase 7-8
   // intent_consultant — handled separately in orchestrator
   // qa_lead, tester — M4
 };

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -55,6 +55,25 @@ export const ComponentsManifestSchema = z.object({
   previews: z.array(z.string()).optional(),
 });
 
+export const TechSpecManifestSchema = z.object({
+  modules: z.array(
+    z.object({
+      name: z.string(),
+      description: z.string(),
+      covers_features: z.array(z.string()),
+    })
+  ),
+  tech_stack: z.array(z.string()),
+  implementation_tasks: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      module: z.string(),
+      covers_features: z.array(z.string()),
+    })
+  ),
+});
+
 // Schema registry by manifest name
 const MANIFEST_SCHEMAS: Record<string, z.ZodType> = {
   'research.manifest.json': ResearchManifestSchema,
@@ -62,6 +81,7 @@ const MANIFEST_SCHEMAS: Record<string, z.ZodType> = {
   'ux-flows.manifest.json': UxFlowsManifestSchema,
   'api-spec.manifest.json': ApiSpecManifestSchema,
   'components.manifest.json': ComponentsManifestSchema,
+  'tech-spec.manifest.json': TechSpecManifestSchema,
 };
 
 export type ResearchManifest = z.infer<typeof ResearchManifestSchema>;
@@ -69,6 +89,7 @@ export type PrdManifest = z.infer<typeof PrdManifestSchema>;
 export type UxFlowsManifest = z.infer<typeof UxFlowsManifestSchema>;
 export type ApiSpecManifest = z.infer<typeof ApiSpecManifestSchema>;
 export type ComponentsManifest = z.infer<typeof ComponentsManifestSchema>;
+export type TechSpecManifest = z.infer<typeof TechSpecManifestSchema>;
 
 export function writeManifest(name: string, data: unknown): void {
   const schema = MANIFEST_SCHEMAS[name];
@@ -139,6 +160,14 @@ const SUMMARY_EXTRACTORS: Record<string, (data: Record<string, unknown>) => stri
     for (const c of m.components) lines.push(`**${c.name}** (\`${c.file}\`) — [${c.covers_features.join(', ')}]`);
     if (m.screenshots.length > 0) lines.push(`**Screenshots:** ${m.screenshots.length} captured`);
     if (m.previews && m.previews.length > 0) lines.push(`**Previews:** ${m.previews.length} generated`);
+    return lines;
+  },
+  'tech-spec.manifest.json': (data) => {
+    const m = data as unknown as TechSpecManifest;
+    const lines: string[] = [];
+    if (m.modules.length > 0) lines.push(`**Modules (${m.modules.length}):** ${m.modules.map((mod) => `${mod.name} [${mod.covers_features.join(', ')}]`).join(', ')}`);
+    if (m.tech_stack.length > 0) lines.push(`**Tech Stack:** ${m.tech_stack.join(', ')}`);
+    if (m.implementation_tasks.length > 0) lines.push(`**Tasks (${m.implementation_tasks.length}):** ${m.implementation_tasks.map((t) => `${t.id}: ${t.name}`).join(', ')}`);
     return lines;
   },
 };


### PR DESCRIPTION
## Summary
Closes #172

First dev-team agent: TechLead reads PRD + UX flows + API spec and outputs a technical specification with architecture, module breakdown, and implementation tasks.

### Steps completed
- [x] #173 — TechLead agent + manifest schema + system prompt

### Key changes
- `src/agents/tech-lead.ts` — LLMAgent subclass
- `.claude/agents/mosaic/tech-lead.md` — System prompt with T-NNN task IDs + Feature ID tracing
- `TechSpecManifestSchema` — modules, tech_stack, implementation_tasks (all with covers_features)
- Registered in agent-factory

🤖 Generated with [Claude Code](https://claude.com/claude-code)