### PR TITLE
feat: Coder Agent — high-autonomy code generation (Phase 7)

### DIFF
--- a/.claude/agents/mosaic/coder.md
+++ b/.claude/agents/mosaic/coder.md
@@ -1,0 +1,45 @@
+# Coder Agent
+
+You are a high-autonomy code generation agent. Your job is to implement the technical specification by writing production-quality code.
+
+## Input
+- `tech-spec.md` — technical specification with architecture, modules, and implementation tasks (T-NNN)
+- `api-spec.yaml` — OpenAPI 3.0 specification for API endpoints
+
+## Process
+
+1. **Read the tech-spec** to understand modules, tasks, and dependencies
+2. **Plan implementation order** based on task priorities and module dependencies
+3. **Write code files** to `.mosaic/artifacts/code/` using the tools available to you
+4. **Self-verify**: after writing all code, run compilation/lint checks to ensure correctness
+5. **Return the manifest** summarizing all generated files
+
+## Output
+
+Your response must be a JSON object with a manifest field:
+
+```json
+{
+  "manifest": {
+    "files": [
+      { "path": "code/src/index.ts", "module": "core", "description": "Entry point" },
+      { "path": "code/src/auth/login.ts", "module": "auth", "description": "Login endpoint handler" }
+    ],
+    "modules": ["core", "auth", "blog"],
+    "covers_tasks": ["T-001", "T-002", "T-003"],
+    "covers_features": ["F-001", "F-002"]
+  }
+}
+```
+
+## Guidelines
+- Write all code files under `.mosaic/artifacts/code/`
+- Follow the tech stack specified in tech-spec.md
+- Every implementation task (T-NNN) from the tech-spec should be covered
+- Every feature (F-NNN) referenced in the tasks should be traced in `covers_features`
+- Write clean, production-quality code — not stubs or placeholders
+- Include proper error handling and type safety
+- If the tech-spec specifies TypeScript, use strict mode
+- After writing code, verify it compiles (run `tsc --noEmit` or equivalent)
+- If compilation fails, fix the errors before returning the manifest
+- Do NOT include test files — those are handled by the Tester agent (M4)

--- a/src/agents/coder.ts
+++ b/src/agents/coder.ts
@@ -1,0 +1,92 @@
+import type { AgentContext } from '../core/types.js';
+import { BaseAgent } from '../core/agent.js';
+import { assemblePrompt, type OutputSpec } from '../core/prompt-assembler.js';
+import { eventBus } from '../core/event-bus.js';
+
+/**
+ * High-autonomy Coder Agent.
+ *
+ * Unlike LLMAgent which uses --json-schema for structured output,
+ * the Coder uses tool use (Read, Write, Bash, Agent) to generate code files,
+ * then returns a manifest summarizing what was produced.
+ *
+ * The agent reads tech-spec → plans modules → writes code files →
+ * self-verifies (compile/lint) → outputs code.manifest.json.
+ */
+export class CoderAgent extends BaseAgent {
+  getOutputSpec(): OutputSpec {
+    return {
+      artifacts: ['code/'],
+      manifest: 'code.manifest.json',
+    };
+  }
+
+  protected async run(context: AgentContext): Promise<void> {
+    const spec = this.getOutputSpec();
+    const prompt = assemblePrompt(context, spec);
+
+    this.logger.agent(this.stage, 'info', 'llm:call', {
+      promptLength: prompt.length,
+    });
+    eventBus.emit('agent:thinking', this.stage, prompt.length);
+
+    // Coder uses allowedTools for autonomous code generation
+    // The LLM will use tools to write files, then return the manifest as JSON
+    const autonomy = context.task.autonomy;
+    const response = await this.provider.call(prompt, {
+      systemPrompt: context.systemPrompt,
+      allowedTools: autonomy?.allowed_tools,
+      maxBudgetUsd: autonomy?.max_budget_usd,
+      jsonSchema: {
+        type: 'object',
+        properties: {
+          manifest: {
+            type: 'object',
+            description: 'The code.manifest.json summarizing all generated files',
+            properties: {
+              files: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    path: { type: 'string' },
+                    module: { type: 'string' },
+                    description: { type: 'string' },
+                  },
+                  required: ['path', 'module', 'description'],
+                },
+              },
+              modules: { type: 'array', items: { type: 'string' } },
+              covers_tasks: { type: 'array', items: { type: 'string' } },
+              covers_features: { type: 'array', items: { type: 'string' } },
+            },
+            required: ['files', 'modules', 'covers_tasks', 'covers_features'],
+          },
+        },
+        required: ['manifest'],
+      },
+    });
+    const raw = response.content;
+
+    this.logger.agent(this.stage, 'info', 'llm:response', {
+      responseLength: raw.length,
+    });
+    eventBus.emit('agent:response', this.stage, raw.length);
+
+    // Parse manifest from response
+    let parsed: { manifest?: unknown };
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      this.logger.agent(this.stage, 'warn', 'llm:json-parse-fallback', {
+        rawLength: raw.length,
+      });
+      parsed = {};
+    }
+
+    // Write manifest
+    if (parsed.manifest) {
+      this.writeOutputManifest('code.manifest.json', parsed.manifest);
+    }
+  }
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -5,4 +5,5 @@ export { UXDesignerAgent } from './ux-designer.js';
 export { APIDesignerAgent } from './api-designer.js';
 export { UIDesignerAgent } from './ui-designer.js';
 export { TechLeadAgent } from './tech-lead.js';
+export { CoderAgent } from './coder.js';
 export { ValidatorAgent } from './validator.js';

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -10,6 +10,7 @@ import {
   APIDesignerAgent,
   UIDesignerAgent,
   TechLeadAgent,
+  CoderAgent,
   ValidatorAgent,
 } from '../agents/index.js';
 
@@ -22,8 +23,9 @@ const AGENT_MAP: Partial<Record<StageName, AgentConstructor>> = {
   api_designer: APIDesignerAgent,
   ui_designer: UIDesignerAgent,
   tech_lead: TechLeadAgent,
+  coder: CoderAgent,
   validator: ValidatorAgent,
-  // coder, reviewer — registered in Phase 7-8
+  // reviewer — registered in Phase 8
   // intent_consultant — handled separately in orchestrator
   // qa_lead, tester — M4
 };

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -74,6 +74,19 @@ export const TechSpecManifestSchema = z.object({
   ),
 });
 
+export const CodeManifestSchema = z.object({
+  files: z.array(
+    z.object({
+      path: z.string(),
+      module: z.string(),
+      description: z.string(),
+    })
+  ),
+  modules: z.array(z.string()),
+  covers_tasks: z.array(z.string()),
+  covers_features: z.array(z.string()),
+});
+
 // Schema registry by manifest name
 const MANIFEST_SCHEMAS: Record<string, z.ZodType> = {
   'research.manifest.json': ResearchManifestSchema,
@@ -82,6 +95,7 @@ const MANIFEST_SCHEMAS: Record<string, z.ZodType> = {
   'api-spec.manifest.json': ApiSpecManifestSchema,
   'components.manifest.json': ComponentsManifestSchema,
   'tech-spec.manifest.json': TechSpecManifestSchema,
+  'code.manifest.json': CodeManifestSchema,
 };
 
 export type ResearchManifest = z.infer<typeof ResearchManifestSchema>;
@@ -90,6 +104,7 @@ export type UxFlowsManifest = z.infer<typeof UxFlowsManifestSchema>;
 export type ApiSpecManifest = z.infer<typeof ApiSpecManifestSchema>;
 export type ComponentsManifest = z.infer<typeof ComponentsManifestSchema>;
 export type TechSpecManifest = z.infer<typeof TechSpecManifestSchema>;
+export type CodeManifest = z.infer<typeof CodeManifestSchema>;
 
 export function writeManifest(name: string, data: unknown): void {
   const schema = MANIFEST_SCHEMAS[name];
@@ -168,6 +183,15 @@ const SUMMARY_EXTRACTORS: Record<string, (data: Record<string, unknown>) => stri
     if (m.modules.length > 0) lines.push(`**Modules (${m.modules.length}):** ${m.modules.map((mod) => `${mod.name} [${mod.covers_features.join(', ')}]`).join(', ')}`);
     if (m.tech_stack.length > 0) lines.push(`**Tech Stack:** ${m.tech_stack.join(', ')}`);
     if (m.implementation_tasks.length > 0) lines.push(`**Tasks (${m.implementation_tasks.length}):** ${m.implementation_tasks.map((t) => `${t.id}: ${t.name}`).join(', ')}`);
+    return lines;
+  },
+  'code.manifest.json': (data) => {
+    const m = data as unknown as CodeManifest;
+    const lines: string[] = [];
+    if (m.files.length > 0) lines.push(`**Files (${m.files.length}):** ${m.files.map((f) => f.path).join(', ')}`);
+    if (m.modules.length > 0) lines.push(`**Modules:** ${m.modules.join(', ')}`);
+    if (m.covers_tasks.length > 0) lines.push(`**Covers tasks:** ${m.covers_tasks.join(', ')}`);
+    if (m.covers_features.length > 0) lines.push(`**Covers features:** ${m.covers_features.join(', ')}`);
     return lines;
   },
 };

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -182,7 +182,8 @@ export class Orchestrator {
 
     try {
       // Build context (artifact isolation)
-      const task = { runId: run.id, stage, instruction: run.instruction };
+      const agentConfig = this.agentsConfig.agents[stage];
+      const task = { runId: run.id, stage, instruction: run.instruction, autonomy: agentConfig?.autonomy };
       const context = buildContext(this.agentsConfig, task);
 
       // Create and execute agent (with clarification handling)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -131,6 +131,7 @@ export interface Task {
   runId: string;
   stage: StageName;
   instruction: string;
+  autonomy?: AgentAutonomyConfig;
 }
 
 export interface AgentContext {


### PR DESCRIPTION
## Summary
Closes #175

High-autonomy Coder agent that reads tech-spec + API spec, writes code files using tool use (Read, Write, Bash, Agent, WebSearch), self-verifies compilation, and returns a code manifest.

### Steps completed
- [x] #176 — Coder Agent implementation — high-autonomy code generation

### Key changes
- `src/agents/coder.ts` — BaseAgent subclass with `allowedTools` + `maxBudgetUsd` from autonomy config
- `.claude/agents/mosaic/coder.md` — System prompt: plan → write → verify → manifest
- `CodeManifestSchema` — files, modules, covers_tasks, covers_features
- `Task.autonomy` field for passing AgentAutonomyConfig to agent context
- Orchestrator passes autonomy config when building task

🤖 Generated with [Claude Code](https://claude.com/claude-code)