### PR TITLE
feat: Reviewer Agent — code vs spec review (Phase 8)

### DIFF
--- a/.claude/agents/mosaic/reviewer.md
+++ b/.claude/agents/mosaic/reviewer.md
@@ -1,0 +1,74 @@
+# Reviewer Agent
+
+You are a code reviewer responsible for verifying that the generated code matches the technical specification and meets quality standards.
+
+## Input
+- `tech-spec.md` — technical specification with modules and implementation tasks (T-NNN)
+- `code/` — generated code files
+- `code.manifest.json` — manifest of generated files and coverage
+
+## Output
+
+Your response must be a JSON object with two fields:
+
+```json
+{
+  "artifact": "...full review-report.md content...",
+  "manifest": {
+    "issues": [
+      { "severity": "critical", "file": "code/src/auth/login.ts", "description": "Missing input validation" },
+      { "severity": "minor", "file": "code/src/index.ts", "description": "Unused import" }
+    ],
+    "spec_coverage": {
+      "total_tasks": 5,
+      "covered_tasks": 4,
+      "missing_tasks": ["T-003"]
+    },
+    "verdict": "pass_with_suggestions"
+  }
+}
+```
+
+## review-report.md Structure
+```markdown
+## Review Summary
+- Verdict: PASS / PASS WITH SUGGESTIONS / FAIL
+- Spec Coverage: X/Y tasks implemented
+- Issues: N total (C critical, M major)
+
+## Spec Coverage Analysis
+### Covered Tasks
+- T-001: Setup project scaffold ✅
+- T-002: Implement auth endpoints ✅
+
+### Missing Tasks
+- T-003: Implement caching layer ❌ (reason)
+
+## Issues Found
+### Critical
+- **[file.ts]** Description of critical issue
+
+### Major
+- **[file.ts]** Description of major issue
+
+### Minor / Suggestions
+- **[file.ts]** Description of suggestion
+```
+
+## Verdict Rules
+- **pass**: All tasks covered, no critical/major issues
+- **pass_with_suggestions**: All tasks covered, only minor issues or suggestions
+- **fail**: Missing tasks, or any critical/major issues found
+
+## Issue Severity
+- **critical**: Security vulnerabilities, data loss risks, broken core functionality
+- **major**: Incorrect behavior, missing error handling, spec violations
+- **minor**: Style issues, non-blocking improvements
+- **suggestion**: Optional enhancements, alternative approaches
+
+## Guidelines
+- Compare code.manifest.json `covers_tasks` against tech-spec implementation_tasks
+- Read each code file referenced in the manifest and check for quality
+- Be strict on spec coverage — missing tasks are a FAIL
+- Be constructive with suggestions — explain why and how to fix
+- If clarification is needed, ask via the clarification field

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -6,4 +6,5 @@ export { APIDesignerAgent } from './api-designer.js';
 export { UIDesignerAgent } from './ui-designer.js';
 export { TechLeadAgent } from './tech-lead.js';
 export { CoderAgent } from './coder.js';
+export { ReviewerAgent } from './reviewer.js';
 export { ValidatorAgent } from './validator.js';

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -1,0 +1,11 @@
+import type { OutputSpec } from '../core/prompt-assembler.js';
+import { LLMAgent } from './llm-agent.js';
+
+export class ReviewerAgent extends LLMAgent {
+  getOutputSpec(): OutputSpec {
+    return {
+      artifacts: ['review-report.md'],
+      manifest: 'review.manifest.json',
+    };
+  }
+}

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -11,6 +11,7 @@ import {
   UIDesignerAgent,
   TechLeadAgent,
   CoderAgent,
+  ReviewerAgent,
   ValidatorAgent,
 } from '../agents/index.js';
 
@@ -24,8 +25,8 @@ const AGENT_MAP: Partial<Record<StageName, AgentConstructor>> = {
   ui_designer: UIDesignerAgent,
   tech_lead: TechLeadAgent,
   coder: CoderAgent,
+  reviewer: ReviewerAgent,
   validator: ValidatorAgent,
-  // reviewer — registered in Phase 8
   // intent_consultant — handled separately in orchestrator
   // qa_lead, tester — M4
 };

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -87,6 +87,22 @@ export const CodeManifestSchema = z.object({
   covers_features: z.array(z.string()),
 });
 
+export const ReviewManifestSchema = z.object({
+  issues: z.array(
+    z.object({
+      severity: z.enum(['critical', 'major', 'minor', 'suggestion']),
+      file: z.string(),
+      description: z.string(),
+    })
+  ),
+  spec_coverage: z.object({
+    total_tasks: z.number(),
+    covered_tasks: z.number(),
+    missing_tasks: z.array(z.string()),
+  }),
+  verdict: z.enum(['pass', 'pass_with_suggestions', 'fail']),
+});
+
 // Schema registry by manifest name
 const MANIFEST_SCHEMAS: Record<string, z.ZodType> = {
   'research.manifest.json': ResearchManifestSchema,
@@ -96,6 +112,7 @@ const MANIFEST_SCHEMAS: Record<string, z.ZodType> = {
   'components.manifest.json': ComponentsManifestSchema,
   'tech-spec.manifest.json': TechSpecManifestSchema,
   'code.manifest.json': CodeManifestSchema,
+  'review.manifest.json': ReviewManifestSchema,
 };
 
 export type ResearchManifest = z.infer<typeof ResearchManifestSchema>;
@@ -105,6 +122,7 @@ export type ApiSpecManifest = z.infer<typeof ApiSpecManifestSchema>;
 export type ComponentsManifest = z.infer<typeof ComponentsManifestSchema>;
 export type TechSpecManifest = z.infer<typeof TechSpecManifestSchema>;
 export type CodeManifest = z.infer<typeof CodeManifestSchema>;
+export type ReviewManifest = z.infer<typeof ReviewManifestSchema>;
 
 export function writeManifest(name: string, data: unknown): void {
   const schema = MANIFEST_SCHEMAS[name];
@@ -192,6 +210,19 @@ const SUMMARY_EXTRACTORS: Record<string, (data: Record<string, unknown>) => stri
     if (m.modules.length > 0) lines.push(`**Modules:** ${m.modules.join(', ')}`);
     if (m.covers_tasks.length > 0) lines.push(`**Covers tasks:** ${m.covers_tasks.join(', ')}`);
     if (m.covers_features.length > 0) lines.push(`**Covers features:** ${m.covers_features.join(', ')}`);
+    return lines;
+  },
+  'review.manifest.json': (data) => {
+    const m = data as unknown as ReviewManifest;
+    const lines: string[] = [];
+    lines.push(`**Verdict:** ${m.verdict}`);
+    lines.push(`**Spec Coverage:** ${m.spec_coverage.covered_tasks}/${m.spec_coverage.total_tasks} tasks`);
+    if (m.spec_coverage.missing_tasks.length > 0) lines.push(`**Missing tasks:** ${m.spec_coverage.missing_tasks.join(', ')}`);
+    if (m.issues.length > 0) {
+      const critical = m.issues.filter((i) => i.severity === 'critical').length;
+      const major = m.issues.filter((i) => i.severity === 'major').length;
+      lines.push(`**Issues:** ${m.issues.length} total (${critical} critical, ${major} major)`);
+    }
     return lines;
   },
 };


### PR DESCRIPTION
## Summary
Closes #178

Reviewer agent reads tech-spec + code manifest + code files, performs spec coverage analysis and quality review, outputs review-report.md with verdict (pass/pass_with_suggestions/fail).

### Steps completed
- [x] #179 — Reviewer Agent implementation — code vs spec review

### Key changes
- `src/agents/reviewer.ts` — LLMAgent subclass
- `.claude/agents/mosaic/reviewer.md` — System prompt with verdict rules + issue severity
- `ReviewManifestSchema` — issues (severity, file, description), spec_coverage (total/covered/missing tasks), verdict
- Registered in agent-factory

🤖 Generated with [Claude Code](https://claude.com/claude-code)