### PR TITLE
fix: README factual errors — checkpoints, validation, clone URL, GitHub App

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Traditional software delivery methodologies — Scrum, Kanban, SAFe — were des
 
 Mosaicat restructures the delivery pipeline around this insight:
 
-- **Humans decide** at two critical points (PRD approval + design review). Everything else is autonomous.
+- **Humans decide** at four critical checkpoints (PRD approval, design review, architecture sign-off, code review). Everything else is autonomous.
 - **Agents coordinate through contracts**, not conversations. Each agent sees only its contracted inputs — never upstream reasoning. Errors stay local instead of propagating through shared context.
-- **Validation is programmatic**, not AI-judged. 8 deterministic checks on structural manifests (~500 bytes each), not 50k-token full-artifact reviews prone to hallucination.
+- **Validation is layered and controlled** — 4 fully deterministic programmatic checks (zero LLM) + 4 LLM checks scoped to structural manifests (~1–2 KB each), replacing 50k-token full-artifact reviews prone to hallucination.
 - **Knowledge accumulates** across runs. Prompt evolution and skill capture turn each delivery into organizational memory — with human approval as the safety gate.
 
 ```
 You:  "Build a personal finance tracker with income/expense logging and monthly reports"
        ↓
-       10 AI agents run autonomously, humans approve at 2 checkpoints
+       10 AI agents run autonomously, humans approve at 4 checkpoints
        ↓
 Out:  Research → PRD → UX Flows → OpenAPI Spec → 25 React Components + Screenshots
       → Tech Spec → Code → Code Review → 8-Check Validation Report
@@ -48,15 +48,15 @@ Out:  Research → PRD → UX Flows → OpenAPI Spec → 25 React Components + S
 
 ### Key Features
 
-- **10 autonomous agents** — mirrors a real product team: PM, designer, architect, coder, reviewer
+- **10 autonomous agents** — mirrors a real product team: consultant, researcher, PM, UX/UI designers, architect, tech lead, coder, reviewer, validator
 - **Configurable approval gates** — full autonomy, full manual, or anything in between per stage
-- **8 deterministic validation checks** — cross-artifact consistency verified without LLM
-- **Feature ID traceability** — `F-001` traced end-to-end from PRD → UX → API → Code → Review
+- **8 layered validation checks** — 4 programmatic (zero LLM, fully deterministic) + 4 LLM-assisted (scoped to lightweight manifests)
+- **Feature ID traceability** — `F-001` traced from PRD → UX → API → Components; task-level (`T-NNN`) from tech spec → code
 - **Visual design output** — React + Tailwind components with Playwright screenshots + HTML gallery
 - **GitHub-native workflow** — Draft PR, stage issues, PR review approval gates — fits existing team processes
 - **Self-evolution with human oversight** — prompt + skill accumulation, all proposals require approval
 - **3 pipeline profiles** — `design-only` / `full` / `frontend-only`, auto-recommended by intent analysis
-- **MCP compatible** — runs inside Claude Code as a tool server
+- **MCP compatible** — integrates with Claude Code as an external tool server
 
 ---
 
@@ -68,7 +68,7 @@ Out:  Research → PRD → UX Flows → OpenAPI Spec → 25 React Components + S
 | **Claude subscription** | [Claude Pro / Team / Enterprise](https://claude.ai/) — Mosaicat calls Claude CLI (`claude -p`) for LLM inference. No separate API key needed. |
 | **Claude CLI** | Installed and authenticated. Run `claude` in your terminal to verify. See [Claude Code docs](https://docs.anthropic.com/en/docs/claude-code/overview) for setup. |
 | **Playwright** (optional) | Required only for UI screenshot generation. Install with `npx playwright install chromium`. |
-| **GitHub account** (optional) | Required only for `--github` mode. Login via `npx tsx src/index.ts login`. |
+| **GitHub App** (optional) | Required only for `--github` mode. Install the [Mosaicat GitHub App](https://github.com/apps/mosaicat) on your target repository, then login via `npx tsx src/index.ts login`. |
 
 > **Enterprise / Team users**: Claude Team and Enterprise plans work out of the box. The pipeline uses `claude -p` with tool use, which is included in all Claude subscriptions. No API key management, no token budgets to configure.
 
@@ -77,7 +77,7 @@ Out:  Research → PRD → UX Flows → OpenAPI Spec → 25 React Components + S
 ## Quick Start
 
 ```bash
-git clone https://github.com/anthropics/mosaicat.git
+git clone https://github.com/ZB-ur/mosaicat.git
 cd mosaicat
 npm install
 ```
@@ -99,8 +99,9 @@ npx tsx src/index.ts run "Build a task management app" --auto-approve
 ### 3. GitHub Mode (team collaboration)
 
 ```bash
-npx tsx src/index.ts login                                    # one-time OAuth
-npx tsx src/index.ts run "Build a task management app" --github
+# 1. Install the Mosaicat GitHub App on your repo: https://github.com/apps/mosaicat
+npx tsx src/index.ts login                                    # 2. one-time OAuth
+npx tsx src/index.ts run "Build a task management app" --github  # 3. run in repo dir
 ```
 
 Creates a Draft PR with stage issues. Team members approve via `/approve` comments on the PR.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,15 +30,15 @@
 
 Mosaicat 围绕这一洞察重构交付流水线：
 
-- **人在两个关键点决策**（PRD 审批 + 设计评审），其余全部自治
+- **人仅在四个关键环节决策**（需求审批、设计评审、架构签署、代码审查），其余全部自治
 - **Agent 通过契约协调**，而非对话。每个 Agent 只看契约输入，绝不看上游推理过程。误差被隔离，不会关联传播
-- **验证是程序化的**，不靠 AI 判断。8 项确定性检查基于结构化 manifest（每份 ~500 字节），而非 50k token 的全量审查
+- **验证分层可控** — 4 项纯程序化检查（零 LLM，完全确定性）+ 4 项 LLM 分析严格限定在结构化 manifest（~1–2 KB）内，取代 50k token 的全量审查
 - **知识跨运行积累**。Prompt 进化和 Skill 捕获让每次交付成为组织记忆 — 人类审批是安全门控
 
 ```
 你:   "做一个个人记账 App，支持收入支出记录和月度报表查看"
        ↓
-       10 个 AI Agent 自主运行，人在 2 个检查点审批
+       10 个 AI Agent 自主运行，人在 4 个关键节点审批
        ↓
 产出: 调研 → PRD → UX 流程 → OpenAPI 规范 → 25 个 React 组件 + 截图
       → 技术方案 → 代码 → 代码审查 → 8 项交叉验证报告
@@ -48,15 +48,15 @@ Mosaicat 围绕这一洞察重构交付流水线：
 
 ### 核心特性
 
-- **10 个自治 Agent** — 模拟真实产品团队：PM、设计师、架构师、开发者、审查者
+- **10 个自治 Agent** — 对应真实产品团队角色：意图顾问、调研员、产品经理、UX/UI 设计师、API 架构师、技术负责人、开发者、审查者、质量校验
 - **可配置审批门控** — 全自治、全人工或按阶段任意组合
-- **8 项确定性验证** — 跨工件一致性校验，无 LLM 参与
-- **Feature ID 端到端追溯** — `F-001` 从 PRD → UX → API → 代码 → 审查全程可追踪
+- **8 项分层验证** — 4 项程序化确定性检查（零 LLM）+ 4 项 manifest 范围 LLM 辅助校验，跨工件一致性保障
+- **Feature ID 分层追溯** — `F-001` 贯穿 PRD → UX → API → 组件；任务级 `T-NNN` 贯穿技术方案 → 代码
 - **可视化设计产出** — React + Tailwind 组件 + Playwright 截图 + HTML 画廊
 - **GitHub 原生工作流** — Draft PR、Stage Issue、PR Review 审批 — 无缝融入现有团队流程
 - **人类监督下的自进化** — Prompt + Skill 积累，所有提案需人工批准
 - **3 种流水线 Profile** — `design-only` / `full` / `frontend-only`，意图分析自动推荐
-- **MCP 兼容** — 可作为 Claude Code 内置工具运行
+- **MCP 兼容** — 作为外部工具服务接入 Claude Code 等 IDE
 
 ---
 
@@ -68,7 +68,7 @@ Mosaicat 围绕这一洞察重构交付流水线：
 | **Claude 订阅** | [Claude Pro / Team / Enterprise](https://claude.ai/) — Mosaicat 通过 Claude CLI（`claude -p`）调用 LLM 推理，无需单独的 API Key。 |
 | **Claude CLI** | 已安装并完成认证。在终端运行 `claude` 验证。安装指南见 [Claude Code 文档](https://docs.anthropic.com/en/docs/claude-code/overview)。 |
 | **Playwright**（可选） | 仅 UI 截图生成需要。安装：`npx playwright install chromium`。 |
-| **GitHub 账号**（可选） | 仅 `--github` 模式需要。通过 `npx tsx src/index.ts login` 登录。 |
+| **GitHub App**（可选） | 仅 `--github` 模式需要。先将 [Mosaicat GitHub App](https://github.com/apps/mosaicat) 安装到目标仓库，再通过 `npx tsx src/index.ts login` 完成 OAuth 授权。 |
 
 > **企业 / 团队用户**：Claude Team 和 Enterprise 计划开箱即用。流水线使用 `claude -p` 的 tool use 能力，所有 Claude 订阅方案均包含此功能。无需管理 API Key，无需配置 token 预算。
 
@@ -77,7 +77,7 @@ Mosaicat 围绕这一洞察重构交付流水线：
 ## 快速开始
 
 ```bash
-git clone https://github.com/anthropics/mosaicat.git
+git clone https://github.com/ZB-ur/mosaicat.git
 cd mosaicat
 npm install
 ```
@@ -99,8 +99,9 @@ npx tsx src/index.ts run "做一个任务管理应用" --auto-approve
 ### 3. GitHub 模式（团队协作）
 
 ```bash
-npx tsx src/index.ts login                                    # 一次性 OAuth 授权
-npx tsx src/index.ts run "做一个任务管理应用" --github
+# 1. 安装 Mosaicat GitHub App 到目标仓库：https://github.com/apps/mosaicat
+npx tsx src/index.ts login                                    # 2. 一次性 OAuth 授权
+npx tsx src/index.ts run "做一个任务管理应用" --github           # 3. 在仓库目录下运行
 ```
 
 创建 Draft PR 和 Stage Issue，团队成员通过 PR 上的 `/approve` 评论审批。


### PR DESCRIPTION
## Summary

Fixes #191

- **"2 checkpoints" → 4**: pipeline.yaml has 4 manual gates (product_owner, ui_designer, tech_lead, reviewer), not 2
- **"8 deterministic checks" → 4+4**: only Check 5-8 are programmatic (zero LLM); Check 1-4 use LLM scoped to manifests
- **"~500 bytes" → ~1-2 KB**: realistic manifest sizes for non-trivial projects
- **Agent roles**: expanded from 5 generic roles to all 10 actual agents
- **Feature ID traceability**: F-NNN traced to Components (not Code/Review); T-NNN from tech spec → code
- **MCP wording**: "runs inside Claude Code" → "integrates with Claude Code as an external tool server"
- **Clone URL**: `anthropics/mosaicat` → `ZB-ur/mosaicat`
- **GitHub App prerequisite**: added install step and link for `--github` mode

All fixes applied to both README.md and README.zh-CN.md.

## Test plan

- [x] Verify all claims against `config/pipeline.yaml`, `src/agents/validator.ts`, `src/auth/resolve-auth.ts`
- [x] Confirm Mermaid diagrams render correctly on GitHub
- [x] Confirm clone URL works: `git clone https://github.com/ZB-ur/mosaicat.git`
- [x] Confirm GitHub App link resolves: https://github.com/apps/mosaicat

🤖 Generated with [Claude Code](https://claude.com/claude-code)