### PR TITLE
feat: M7 Phase N — Skill 系统激活 + Evolution 默认开启

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -109,7 +109,7 @@ github:
     - "/reject"
 
 evolution:
-  enabled: false
+  enabled: true
   cooldown_hours: 24
 
 # LLM provider pool — configure which models are available

--- a/config/skills/builtin/acceptance-test-strategy/SKILL.md
+++ b/config/skills/builtin/acceptance-test-strategy/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: acceptance-test-strategy
+description: Acceptance test layering strategy and framework selection
+scope: shared
+agents: [qa_lead]
+trigger: always
+---
+
+## Three Test Layers
+1. Feature acceptance (tests/acceptance/features/)
+   - One test file per F-NNN feature
+   - Use Testing Library + happy-dom
+   - Test user behavior, not implementation details
+
+2. Interaction flows (tests/acceptance/flows/)
+   - One test file per UX flow
+   - Multi-step operations via userEvent
+   - Verify UI state at each flow step
+
+3. API contracts (tests/acceptance/api/)
+   - Generated from OpenAPI spec
+   - Verify endpoint exists and response shape is correct
+   - Use supertest or fetch for direct requests
+
+## Framework Selection
+- Default: vitest + @testing-library/react + happy-dom
+- E2E (critical flows only): playwright
+- API: vitest + fetch/supertest

--- a/config/skills/builtin/architecture-patterns/SKILL.md
+++ b/config/skills/builtin/architecture-patterns/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: web-app-architecture
+description: Web app architecture patterns and dynamic constitution generation guide
+scope: shared
+agents: [tech_lead]
+trigger: always
+---
+
+## Constitution Generation Guide
+Dynamic constitution MUST include:
+1. Tech stack declaration (framework + version + key deps)
+2. File structure convention (directory meanings, naming rules)
+3. Naming conventions (components PascalCase, hooks useCamelCase, API snake_case)
+4. Verification commands (tsc, build, test — exact commands)
+5. At least 3 NEVER rules (project-level prohibitions)
+
+## Module Split Rules
+- Split by feature, not by technical layer
+- Each module: max 8 files
+- Shared types and utils go in shared/ module (priority 0)
+- Page-level modules contain: page + components + hooks + services

--- a/config/skills/builtin/form-validation/SKILL.md
+++ b/config/skills/builtin/form-validation/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: form-validation
+description: Standard form validation pattern (avoid hand-written if/else causing fix loops)
+scope: shared
+agents: [coder]
+trigger: code-plan 包含表单
+---
+
+## Rules
+- Use zod schema for validation rules, never hand-write if/else chains
+- Error messages defined in schema (z.string().min(1, "Required"))
+- Use react-hook-form + zodResolver for integration
+- Submit triggers full validation, input triggers per-field validation
+
+## Source
+Multiple pipeline runs observed: hand-written if/else validation causes 3+ fix rounds

--- a/config/skills/builtin/react-project-setup/SKILL.md
+++ b/config/skills/builtin/react-project-setup/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: react-project-setup
+description: React + TypeScript + Vite project standard setup pattern
+scope: shared
+agents: [coder]
+trigger: tech-spec 包含 React
+---
+
+## Project Structure
+```
+src/
+  components/    # By feature subdirectory, not by type
+  pages/         # Page-level components, 1:1 with routes
+  hooks/         # Custom hooks
+  services/      # API call layer — components never fetch directly
+  types/         # Shared type definitions
+  lib/           # Utility functions
+```
+
+## Key Rules
+- App.tsx declares all routes centrally — components do not self-register
+- Each page component exports default, routes use lazy() loading
+- services/ has one function per API endpoint with explicit return types
+- All component props must have TypeScript interface, defined at top of same file
+- Use index.ts barrel exports sparingly — only for public module APIs

--- a/config/skills/builtin/state-management/SKILL.md
+++ b/config/skills/builtin/state-management/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: state-management-patterns
+description: Frontend state management selection and implementation patterns
+scope: shared
+agents: [coder, tech_lead]
+trigger: tech-spec 包含状态管理
+---
+
+## Selection Rules
+- Simple apps (<10 state slices): Zustand
+- Need devtools + middleware: Zustand
+- Server state (API caching): TanStack Query
+- Do NOT use Redux (unless tech-spec explicitly requires it)
+- Do NOT use React Context for global state (performance issues)
+
+## Zustand Patterns
+- One store per feature (not a single global store)
+- Store files go in stores/ directory
+- Actions and state defined in the same store
+- Use selectors for derived state

--- a/config/skills/builtin/ux-interaction-patterns/SKILL.md
+++ b/config/skills/builtin/ux-interaction-patterns/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: ux-interaction-patterns
+description: Standard UX interaction patterns for common UI elements
+scope: shared
+agents: [ux_designer]
+trigger: always
+---
+
+## Standard Interaction Patterns
+- Lists: swipe-to-delete / long-press multi-select / pull-to-refresh
+- Forms: real-time validation + submit validation, error below field
+- Navigation: mobile bottom tabs / desktop sidebar
+- Loading: skeleton (lists) / spinner (buttons) / progress bar (uploads)
+- Empty state: illustration + guide text + primary action button
+- Error: toast (light) / inline (forms) / full-screen (fatal)
+
+## Every Flow Must Cover
+- Happy path (normal flow)
+- Error state (what user sees on error)
+- Empty state (no data)
+- Loading state (data loading)

--- a/src/core/context-manager.ts
+++ b/src/core/context-manager.ts
@@ -31,20 +31,6 @@ export function buildContext(
     // Static constitution file not found — non-blocking
   }
 
-  // Inject approved skills into system prompt
-  try {
-    const skills = loadSkillsForAgent(task.stage);
-    if (skills.size > 0) {
-      let skillSection = '\n\n## Available Skills\n';
-      for (const [name, content] of skills) {
-        skillSection += `\n### Skill: ${name}\n${content}\n`;
-      }
-      systemPrompt += skillSection;
-    }
-  } catch (err) {
-    console.warn(`[context-manager] Failed to load skills for ${task.stage}: ${err instanceof Error ? err.message : String(err)}`);
-  }
-
   // Load only contracted input artifacts (artifact isolation)
   const inputArtifacts = new Map<string, string>();
   for (const input of config.inputs) {
@@ -58,6 +44,22 @@ export function buildContext(
     } else if (artifactExists(input)) {
       inputArtifacts.set(input, readArtifact(input));
     }
+  }
+
+  // Inject approved skills into system prompt (after artifacts loaded for trigger context)
+  try {
+    // Build task context from loaded artifacts for trigger matching
+    const taskContext = [...inputArtifacts.values()].join('\n').slice(0, 10000);
+    const skills = loadSkillsForAgent(task.stage, taskContext);
+    if (skills.size > 0) {
+      let skillSection = '\n\n## Available Skills\n';
+      for (const [name, content] of skills) {
+        skillSection += `\n### Skill: ${name}\n${content}\n`;
+      }
+      systemPrompt += skillSection;
+    }
+  } catch (err) {
+    console.warn(`[context-manager] Failed to load skills for ${task.stage}: ${err instanceof Error ? err.message : String(err)}`);
   }
 
   return {

--- a/src/evolution/skill-manager.ts
+++ b/src/evolution/skill-manager.ts
@@ -4,6 +4,7 @@ import type { StageName } from '../core/types.js';
 import type { EvolutionProposal, SkillInfo, SkillScope } from './types.js';
 
 const SKILLS_DIR = '.mosaic/evolution/skills';
+const BUILTIN_DIR = path.join('config', 'skills', 'builtin');
 const SKILLS_INDEX = path.join(SKILLS_DIR, 'skills.json');
 
 // Artifact names that are stage-specific (used for scope classification)
@@ -33,6 +34,76 @@ function saveSkillsIndex(skills: SkillInfo[]): void {
   fs.writeFileSync(SKILLS_INDEX, JSON.stringify(skills, null, 2));
 }
 
+/**
+ * Parse YAML frontmatter from a SKILL.md file.
+ * Returns metadata fields and the content after frontmatter.
+ */
+function parseSkillFrontmatter(raw: string): {
+  metadata: Record<string, string>;
+  content: string;
+} {
+  const fmMatch = raw.match(/^---\n([\s\S]*?)\n---\n*([\s\S]*)/);
+  if (!fmMatch) return { metadata: {}, content: raw };
+
+  const metadata: Record<string, string> = {};
+  for (const line of fmMatch[1].split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx > 0) {
+      const key = line.slice(0, colonIdx).trim();
+      const value = line.slice(colonIdx + 1).trim();
+      metadata[key] = value;
+    }
+  }
+
+  return { metadata, content: fmMatch[2] };
+}
+
+// ─── Built-in Skills ──────────────────────────────────────
+
+/**
+ * Load built-in skills from .mosaic/evolution/skills/builtin/.
+ * Built-in skills have highest priority and cannot be modified by evolution.
+ */
+function loadBuiltinSkills(): SkillInfo[] {
+  const skills: SkillInfo[] = [];
+
+  if (!fs.existsSync(BUILTIN_DIR)) return skills;
+
+  try {
+    const entries = fs.readdirSync(BUILTIN_DIR, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const skillFile = path.join(BUILTIN_DIR, entry.name, 'SKILL.md');
+      if (!fs.existsSync(skillFile)) continue;
+
+      const raw = fs.readFileSync(skillFile, 'utf-8');
+      const { metadata } = parseSkillFrontmatter(raw);
+
+      // Parse agents field (YAML array like [coder, tech_lead])
+      const agentsStr = metadata.agents ?? '';
+      const agents = agentsStr.replace(/[\[\]]/g, '').split(',').map(s => s.trim()).filter(Boolean);
+      const primaryAgent = (agents[0] ?? 'coder') as StageName;
+
+      skills.push({
+        name: metadata.name ?? entry.name,
+        scope: (metadata.scope as SkillScope) ?? 'shared',
+        description: metadata.description ?? '',
+        agentStage: primaryAgent,
+        filePath: skillFile,
+        proposalId: 'builtin',
+        createdAt: 'builtin',
+        trigger: metadata.trigger,
+        builtin: true,
+      });
+    }
+  } catch { /* directory read error */ }
+
+  return skills;
+}
+
+// ─── Scope Classification ──────────────────────────────────
+
 export function classifyScope(proposal: EvolutionProposal): SkillScope {
   if (proposal.skillMetadata?.scope) {
     return proposal.skillMetadata.scope;
@@ -47,6 +118,8 @@ export function classifyScope(proposal: EvolutionProposal): SkillScope {
 
   return 'shared';
 }
+
+// ─── Skill Persistence ─────────────────────────────────────
 
 export function persistSkill(proposal: EvolutionProposal): SkillInfo {
   if (!proposal.skillMetadata) {
@@ -68,17 +141,22 @@ export function persistSkill(proposal: EvolutionProposal): SkillInfo {
   ensureDir(skillDir);
   const filePath = path.join(skillDir, 'SKILL.md');
 
+  const triggerLine = proposal.skillMetadata.trigger
+    ? `trigger: ${proposal.skillMetadata.trigger}\n`
+    : '';
+
   const frontmatter = [
     '---',
     `name: ${name}`,
     `description: ${proposal.skillMetadata.description}`,
     `scope: ${scope}`,
     `agent: ${proposal.agentStage}`,
+    triggerLine ? triggerLine.trim() : undefined,
     `created: ${new Date().toISOString()}`,
     `proposal: ${proposal.id}`,
     '---',
     '',
-  ].join('\n');
+  ].filter(Boolean).join('\n');
 
   fs.writeFileSync(filePath, frontmatter + proposal.proposedContent);
 
@@ -90,6 +168,7 @@ export function persistSkill(proposal: EvolutionProposal): SkillInfo {
     filePath,
     proposalId: proposal.id,
     createdAt: new Date().toISOString(),
+    trigger: proposal.skillMetadata.trigger,
   };
 
   const skills = loadSkillsIndex();
@@ -105,25 +184,151 @@ export function persistSkill(proposal: EvolutionProposal): SkillInfo {
   return skillInfo;
 }
 
+// ─── Skill Listing ──────────────────────────────────────────
+
 export function listSkills(stage: StageName): SkillInfo[] {
-  const skills = loadSkillsIndex();
-  return skills.filter(
-    (s) => s.scope === 'shared' || s.agentStage === stage
-  );
+  // Load from index + builtin, deduplicate (builtin wins on name conflict)
+  const indexSkills = loadSkillsIndex();
+  const builtinSkills = loadBuiltinSkills();
+
+  const byName = new Map<string, SkillInfo>();
+
+  // Index skills first (lower priority)
+  for (const s of indexSkills) {
+    if (s.scope === 'shared' || s.agentStage === stage) {
+      byName.set(s.name, s);
+    }
+  }
+
+  // Builtin skills override (highest priority)
+  for (const s of builtinSkills) {
+    // Check if this builtin applies to this stage
+    const raw = fs.existsSync(s.filePath) ? fs.readFileSync(s.filePath, 'utf-8') : '';
+    const { metadata } = parseSkillFrontmatter(raw);
+    const agentsStr = metadata.agents ?? '';
+    const agents = agentsStr.replace(/[\[\]]/g, '').split(',').map(a => a.trim());
+
+    if (s.scope === 'shared' || agents.includes(stage) || s.agentStage === stage) {
+      byName.set(s.name, s);
+    }
+  }
+
+  // Filter out deprecated skills
+  return [...byName.values()].filter(s => !s.deprecated);
 }
 
-export function loadSkillsForAgent(stage: StageName): Map<string, string> {
+// ─── Progressive Disclosure ─────────────────────────────────
+
+/**
+ * Load skills for an agent with progressive disclosure.
+ * - Skills with matching triggers: full content injected
+ * - Skills without matching triggers: only name + description (summary)
+ * - Skills with trigger="always": always fully loaded
+ *
+ * @param stage The agent stage
+ * @param taskContext Optional context string to match triggers against (e.g., input artifacts)
+ */
+export function loadSkillsForAgent(
+  stage: StageName,
+  taskContext?: string,
+): Map<string, string> {
   const skills = listSkills(stage);
   const result = new Map<string, string>();
 
   for (const skill of skills) {
-    if (fs.existsSync(skill.filePath)) {
-      const raw = fs.readFileSync(skill.filePath, 'utf-8');
-      // Strip YAML frontmatter if present
-      const content = raw.replace(/^---\n[\s\S]*?\n---\n*/, '');
+    if (!fs.existsSync(skill.filePath)) continue;
+
+    const raw = fs.readFileSync(skill.filePath, 'utf-8');
+    const { content } = parseSkillFrontmatter(raw);
+    const trigger = skill.trigger;
+
+    // Determine if this skill should be fully loaded
+    const shouldFullLoad = !trigger
+      || trigger === 'always'
+      || (taskContext && matchesTrigger(trigger, taskContext));
+
+    if (shouldFullLoad) {
       result.set(skill.name, content);
+    } else {
+      // Progressive disclosure: only inject summary
+      result.set(skill.name, `[Available skill: ${skill.description}]`);
     }
   }
 
   return result;
+}
+
+/**
+ * Simple trigger matching: check if any keyword in the trigger
+ * appears in the task context.
+ */
+function matchesTrigger(trigger: string, context: string): boolean {
+  // Split trigger into keywords (Chinese or English, ignoring common words)
+  const keywords = trigger
+    .split(/[\s,，、]+/)
+    .filter(k => k.length > 1)
+    .map(k => k.toLowerCase());
+
+  const contextLower = context.toLowerCase();
+  return keywords.some(k => contextLower.includes(k));
+}
+
+// ─── Skill Lifecycle Management ─────────────────────────────
+
+/**
+ * Record that a skill was used in a pipeline run.
+ */
+export function recordSkillUsage(skillName: string, stage: StageName, _runId: string): void {
+  const skills = loadSkillsIndex();
+  const skill = skills.find(s => s.name === skillName);
+  if (skill) {
+    skill.usageCount = (skill.usageCount ?? 0) + 1;
+    skill.lastUsedAt = new Date().toISOString();
+    saveSkillsIndex(skills);
+  }
+}
+
+/**
+ * Get usage statistics for a skill.
+ */
+export function getSkillStats(skillName: string): {
+  usageCount: number;
+  lastUsedAt?: string;
+  deprecated: boolean;
+} | null {
+  const skills = loadSkillsIndex();
+  const skill = skills.find(s => s.name === skillName);
+  if (!skill) return null;
+  return {
+    usageCount: skill.usageCount ?? 0,
+    lastUsedAt: skill.lastUsedAt,
+    deprecated: skill.deprecated ?? false,
+  };
+}
+
+/**
+ * Mark skills as deprecated if unused for longer than threshold.
+ */
+export function pruneUnusedSkills(thresholdDays: number): string[] {
+  const skills = loadSkillsIndex();
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - thresholdDays);
+  const pruned: string[] = [];
+
+  for (const skill of skills) {
+    // Never prune builtin skills
+    if (skill.builtin) continue;
+
+    const lastUsed = skill.lastUsedAt ? new Date(skill.lastUsedAt) : new Date(skill.createdAt);
+    if (lastUsed < cutoff && !skill.deprecated) {
+      skill.deprecated = true;
+      pruned.push(skill.name);
+    }
+  }
+
+  if (pruned.length > 0) {
+    saveSkillsIndex(skills);
+  }
+
+  return pruned;
 }

--- a/src/evolution/types.ts
+++ b/src/evolution/types.ts
@@ -19,12 +19,20 @@ export interface SkillMetadata {
   name: string;
   scope: SkillScope;
   description: string;
+  trigger?: string;
+  usageCount?: number;
+  lastUsedAt?: string;
+  deprecated?: boolean;
 }
 
 export const SkillMetadataSchema = z.object({
   name: z.string().min(1),
   scope: z.enum(SKILL_SCOPES),
   description: z.string().min(1),
+  trigger: z.string().optional(),
+  usageCount: z.number().optional(),
+  lastUsedAt: z.string().optional(),
+  deprecated: z.boolean().optional(),
 });
 
 // --- Evolution Proposal ---
@@ -105,6 +113,11 @@ export interface SkillInfo {
   filePath: string;
   proposalId: string;
   createdAt: string;
+  trigger?: string;
+  usageCount?: number;
+  lastUsedAt?: string;
+  deprecated?: boolean;
+  builtin?: boolean;
 }
 
 export const SkillInfoSchema = z.object({
@@ -115,6 +128,11 @@ export const SkillInfoSchema = z.object({
   filePath: z.string(),
   proposalId: z.string(),
   createdAt: z.string(),
+  trigger: z.string().optional(),
+  usageCount: z.number().optional(),
+  lastUsedAt: z.string().optional(),
+  deprecated: z.boolean().optional(),
+  builtin: z.boolean().optional(),
 });
 
 // --- LLM Proposal Candidate (raw response from evolution analyst) ---


### PR DESCRIPTION
## Summary
Closes #309

M7 Phase N: Builtin skills, progressive disclosure, evolution enabled by default, and skill lifecycle management.

Depends on Phase M PR #308.

### Steps completed
- [x] #310 — Built-in skills + progressive disclosure + evolution enable + skill lifecycle

### Key changes
- **6 built-in skills** in config/skills/builtin/ (git-tracked, highest priority)
- **Progressive disclosure:** trigger-matched skills get full content, others get summary only
- **Skill lifecycle:** usage tracking, stats, auto-deprecation of unused skills
- **Evolution:** enabled by default in pipeline.yaml
- **Context-manager:** passes artifact context for trigger matching

Generated with [Claude Code](https://claude.com/claude-code)